### PR TITLE
Add Infrastructure to automagically inform PRs about updates on master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,15 @@ sudo: false
 language: python
 
 python:
-  - "3.5"
+  - '3.5'
 
 env:
   global:
     - BEAVY_ENV=TEST
+    - secure: 42qbN2sBRUwB8q99XdMJDsr1FelB3fUA8wRjRbH7ZGKRDH6CKHALno/RV2QIzpbJTlwi/6ax5MV3FQTEPN5p726Zj1JiwOun3RW2kRdqCm/xNGyh4B5FxJxyzq0hSIFdJCXihJd1Frm2JltHMkRCadl6VtlmdY9L7N1SRHQoJs0X4wU354LJFpDu2trBZKESUWee73VgdynDwlT6nehwcj42TxyXt9lr3moZUHLIfXvnyMFL7tp1CDMdbAkD4m1hq1UG1jxHQRbHfzTEtem+8oVAi8I3Hrpds4/lnIjP6/LJi8bR3c9rKKykKe1EKZnhYUf/lwD00jdR4g8c1tR3F/kTByFjxGFRfpRUzJXi6dD8Q2JOdu8zVAuIgnZg2Gh+c5z+V3/L27ax1x4sYyiXbi/lQpbE6XSkn4wLWi9Y1TK1kl1N92NkVipLwHz535tcWLwQ9KwzpVUBznGcYw5XQO3sbVcSF4PiEpiET+MjwV5o5MkOfD67FATZo9GlSwKpmSoSsd2JgpjzieRNt+VDyC4liDWco2HA3191DSO2f/q91w3bpwlGRCKP/X78npeIVGCMOzWSnTmPtOLZd3MjC/g/HFb90SG6cjAC1nTkR8RHTAXYBSnUZgr1Gl/8A1I86LSDKhXGoBGHjJTFt0ViAX+Ho9Yn0LCrtrN7SeiuSEs=
   matrix:
     - APP=minima
     - APP=hacker_news
-    # --------------------- HERE -------------------
-    # ADD YOUR APP HERE (and outcomments some others)
-    # to make your travis run against your App tests,
-    # like so:
-    # - APP=my_app
-    # --------------------- HERE -------------------
 
 before_install:
   # use NVM to install latest stable NODE – the predelivered
@@ -29,14 +24,9 @@ before_install:
   - npm install
 
 before_script:
-  # setup test database
   - psql -c 'create database "beavy-test";' -U postgres
-  # copy our test configuration to main
   - cp -f "beavy_apps/$APP/tests/config.yml" config.yml
-  # building the javascript & js
   - npm run build
-  # and migrate the database – this needs the manifest.json
-  # and can only happen after the npm build!
   - python manager.py db upgrade heads
 
 
@@ -45,23 +35,24 @@ script:
   - py.test beavy beavy_modules beavy_apps
   # lets run jstests
   - npm test
-
   # starting up test-server
   - flask --app=main run &
   # and running behaviour tests against it
   - python manager.py behave_tests
 
+after_success:
+  - python scripts/travis_after_all.py && python scripts/auto_pr.py || echo "skipped"
 
 cache:
-    directories:
-        - $HOME/.cache/pip
+  directories:
+    - $HOME/.cache/pip
 
 services:
   - redis-server
 
 addons:
   ssh_known_hosts: github.com
-  postgresql: "9.4"
+  postgresql: '9.4'
   code_climate:
     repo_token: 267de20fcb1419ff02cfe22e5009111ffc86347f398762cbb700ad56f8279ca6
 
@@ -69,6 +60,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/e72c826c6364f1f79f02
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always
+    on_success: change
+    on_failure: always
+    on_start: never

--- a/scripts/auto_pr.py
+++ b/scripts/auto_pr.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import json
+import time
+import logging
+
+import urllib.request as urllib2
+from urllib.error import HTTPError
+
+REPO = "beavyHQ/beavy"
+BRANCHES = ("master", )
+
+log = logging.getLogger("travis.leader")
+log.addHandler(logging.StreamHandler())
+log.setLevel(logging.INFO)
+
+if os.getenv("TRAVIS_PULL_REQUEST") != 'false':
+    print("We are building a PR – Skipping")
+    sys.exit(0)
+
+branch = os.getenv('TRAVIS_BRANCH')
+repo = os.getenv('TRAVIS_REPO_SLUG')
+gh_token = os.getenv('GITHUB_TOKEN', None)
+
+if repo != REPO or branch not in BRANCHES:
+    print("We only autodeploy from travis when building {} of {}".format(",".join(BRANCHES), REPO))
+    sys.exit(0)
+elif not gh_token:
+    print("{} not found. exiting.".format(GITHUB_TOKEN))
+    sys.exit(0)
+
+user = repo.split('/')[0]
+
+BASE_HEADERS ={
+        'Authorization': 'token {}'.format(gh_token),
+        'content-type': 'application/json'
+    }
+
+
+def query_github(query, payload={}, **headers):
+    headers.update(BASE_HEADERS)
+    data = json.dumps(payload).encode("utf-8") if payload else None
+    req = urllib2.Request("https://api.github.com{0}".format(query),
+                          data, headers)
+    resp = json.loads(urllib2.urlopen(req).read().decode("utf-8"))
+    return resp
+
+print(" – Fetching forks")
+
+for fork in query_github("/repos/{0}/forks".format(repo)):
+    full_name = fork["full_name"]
+    default_branch = fork["default_branch"]
+
+    if default_branch == 'master':
+        print("Skipping {} – it's set to master.".format(full_name))
+        continue
+
+    pulls = query_github("/repos/{0}/pulls?open=true&head={1}:{2}".format(
+                         full_name, repo, branch))
+
+    if pulls:
+        print("Skipping {} – it still has a PR pending (which should update automagically)".format(full_name))
+        continue
+
+    try:
+        pr = query_github("/repos/{0}/pulls".format(full_name), {
+            "title": "✨ Merge new upstream updates ✨",
+            "head": "{}:{}".format(user, branch),
+            "base": default_branch,
+# FIXME: make this more specific to the PR itself
+# FIXME: switch this to an automatic bot
+# FIXME: add link to docs about this, and allow ppl to turn this off
+        "body": """Hello,
+
+We've made a lot of improvements on the upstream version of the beavy project.
+You might want to consider merging them in. This PR contains the latest state
+we have upstream.
+
+If something breaks, we'd appreciate if you could let us know about it.
+
+Thanks!
+Beavy
+
+-----
+This is an automatic service provided to you as you forked the repo and
+switched the default branch – thus making us believe you are building
+your own version on top of beavy.
+"""
+
+        })
+    except HTTPError as exc:
+        print("Error {0} – sending PR failed: {1}".format(full_name, exc))
+    else:
+        print("Success {0} – PR send for {1} {2} ".format(full_name, default_branch, pr["url"]))

--- a/scripts/travis_after_all.py
+++ b/scripts/travis_after_all.py
@@ -1,0 +1,87 @@
+from functools import reduce
+import urllib.request as urllib2
+
+import json
+import time
+import os
+
+
+travis_entry = 'https://api.travis-ci.org'
+build_id = os.getenv("TRAVIS_BUILD_ID")
+polling_interval = int(os.getenv("POLLING_INTERVAL", '5'))
+gh_token = os.getenv("GITHUB_TOKEN")
+job_number = os.getenv("TRAVIS_JOB_NUMBER")
+
+is_leader = lambda job: job.endswith('.1')
+
+if not job_number:
+    # seems even for builds with only one job, this won't get here
+    print("Don't use defining leader for build without matrix")
+    exit(1)
+elif not is_leader(job_number):
+    print("not the leader")
+    exit(1)
+
+
+class MatrixElement(object):
+    def __init__(self, json_raw):
+        self.is_finished = json_raw['finished_at'] is not None
+        self.is_succeeded = json_raw['result'] == 0
+        self.number = json_raw['number']
+        self.is_leader = is_leader(self.number)
+
+
+def matrix_snapshot(travis_token):
+    """
+    :return: Matrix List
+    """
+    headers = {'content-type': 'application/json', 'Authorization': 'token {}'.format(travis_token)}
+    req = urllib2.Request("{0}/builds/{1}".format(travis_entry, build_id), headers=headers)
+    response = urllib2.urlopen(req).read().decode("utf-8")
+    raw_json = json.loads(response)
+    matrix_without_leader = [MatrixElement(job) for job in raw_json["matrix"] if not is_leader(job['number'])]
+    return matrix_without_leader
+
+
+def wait_others_to_finish(travis_token):
+    def others_finished():
+        """
+        Dumps others to finish
+        Leader cannot finish, it is working now
+        :return: tuple(True or False, List of not finished jobs)
+        """
+        snapshot = matrix_snapshot(travis_token)
+        finished = [job.is_finished for job in snapshot if not job.is_leader]
+        return reduce(lambda a, b: a and b, finished), [job.number for job in snapshot if
+                                                        not job.is_leader and not job.is_finished]
+
+    while True:
+        finished, waiting_list = others_finished()
+        if finished:
+            break
+        print("Leader waits for minions {0}...".format(waiting_list))  # just in case do not get "silence timeout"
+        time.sleep(polling_interval)
+
+
+def get_token():
+    assert gh_token, 'GITHUB_TOKEN is not set'
+    data = {"github_token": gh_token}
+    headers = {'content-type': 'application/json'}
+
+    req = urllib2.Request("{0}/auth/github".format(travis_entry), json.dumps(data).encode("utf-8"), headers)
+    response = urllib2.urlopen(req).read().decode("utf-8")
+    travis_token = json.loads(response).get('access_token')
+
+    return travis_token
+
+
+token = get_token()
+wait_others_to_finish(token)
+
+final_snapshot = matrix_snapshot(token)
+print("Final Results: {0}".format([(e.number, e.is_succeeded) for e in final_snapshot]))
+
+others_snapshot = [el for el in final_snapshot if not el.is_leader]
+if reduce(lambda a, b: a and b, [e.is_succeeded for e in others_snapshot]):
+    print("Succeeded – continue.")
+    exit(0)


### PR DESCRIPTION
Turns out that Travis doesn't provide a nice way to deploy only once
from the build when using the matrix-system, so this adds the workaround
script to emulate that behaviour.

When all builds pass the custom python auto-pr script will be called.
Given this is a travis build of beavyHQ/beavy on master, it will fetch
all forks and send a PR to those with a custom default branch to 
include the new changes. If such an open PR is already present, it will
be skipped as Github takes care of that already.

This should allow for an easy continuous-integration flow with customisation
development on top of beavy. Illustrated using the techtalks repo at the
moment.


Note: as of now, this is using my personal github account to send the PR.