### PR TITLE
Extract external URL Information Module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
 
 script:
   # we are starting with running all unit tests
-  - py.test --cov-config .coveragerc --cov=beavy --cov=beavy_modules --cov=beavy_apps beavy beavy_modules beavy_apps
+  - python manager.py pytest
   # lets run jstests – currently without reporitng
   - npm test
   # starting up test-server

--- a/beavy/app.py
+++ b/beavy/app.py
@@ -5,6 +5,7 @@ from flask.ext.marshmallow import Marshmallow
 from flask.ext.migrate import Migrate, MigrateCommand
 from flask.ext.security import Security, SQLAlchemyUserDatastore, current_user
 from flask.ext.security.utils import encrypt_password
+from flask.ext.cache import Cache
 from flask_mail import Mail
 from flask_limiter import Limiter
 from flask_admin import Admin, AdminIndexView
@@ -134,6 +135,9 @@ mail = Mail(app)
 
 # limit access to the app
 limiter = Limiter(app)
+
+# add caching support
+cache = Cache(app)
 
 
 #  ------ Database setup is done after here ----------

--- a/beavy/app.py
+++ b/beavy/app.py
@@ -8,6 +8,7 @@ from flask.ext.security.utils import encrypt_password
 from flask.ext.cache import Cache
 from flask_mail import Mail
 from flask_limiter import Limiter
+from flask_limiter.util import get_ipaddr
 from flask_admin import Admin, AdminIndexView
 
 from flask_social_blueprint.core import SocialBlueprint as SocialBp
@@ -105,6 +106,10 @@ class BeavyAdminIndexView(AdminIndexView):
 
         return False
 
+def _limiter_key():
+    if current_user.is_authenticated():
+        return "u_{}".format(current_user.id)
+    return "ip_{}".format(get_ipaddr())
 # --------------------------- Setting stuff up in order ----------
 
 
@@ -134,7 +139,10 @@ babel = Babel(app)
 mail = Mail(app)
 
 # limit access to the app
-limiter = Limiter(app)
+limiter = Limiter(app, key_func=_limiter_key)
+# configure logging for limiter
+for handler in app.logger.handlers:
+    limiter.logger.addHandler(handler)
 
 # add caching support
 cache = Cache(app)

--- a/beavy/common/rate_limits.py
+++ b/beavy/common/rate_limits.py
@@ -1,0 +1,9 @@
+from beavy.app import limiter, app
+from functools import wraps
+
+def rate_limit(default, *args, **kwargs):
+    def inner(fn):
+        key = "{}.{}".format(fn.__module__, fn.__name__)
+        print(key)
+        return limiter.limit(app.config.get("RATELIMITS", {}).get(key, default), *args, **kwargs)(fn)
+    return inner

--- a/beavy/common/rate_limits.py
+++ b/beavy/common/rate_limits.py
@@ -1,7 +1,7 @@
-from beavy.app import limiter, app
 from functools import wraps
 
 def rate_limit(default, *args, **kwargs):
+    from beavy.app import limiter, app
     def inner(fn):
         key = "{}.{}".format(fn.__module__, fn.__name__)
         print(key)

--- a/beavy/config.yml
+++ b/beavy/config.yml
@@ -16,6 +16,12 @@ COMMON: &common
   # to 15minutes
   CACHE_DEFAULT_TIMEOUT: 900
 
+  RATELIMITS:
+    # custom rate limits:
+    # full.path.module.view : "RATE LIMIT"
+    # see https://flask-limiter.readthedocs.org/en/stable/#rate-limit-string-notation
+    beavy.views.lists.latest.latest: "1/second"
+
 DEVELOPMENT: &development
   <<: *common
   DEBUG: True
@@ -45,5 +51,7 @@ PRODUCTION: &production
   CELERY_RESULT_BACKEND: 'rpc://'
   CELERY_RESULT_PERSISTENT: False
   SQLALCHEMY_DATABASE_URI: "postgresql://postgres@db/beavy"
+  RATELIMIT_STORAGE_URL: redis://localhost:6379/2
+  RATELIMIT_STRATEGY: moving-window
   CACHE_TYPE: redis
   CACHE_REDIS_URL: redis://localhost:6379/2

--- a/beavy/config.yml
+++ b/beavy/config.yml
@@ -9,6 +9,12 @@ COMMON: &common
   RATELIMIT_GLOBAL: "200/hour"
   HOME_URL: '/hello'
 
+  # CACHE STUFF
+  CACHE_TYPE: "null"
+  CACHE_NO_NULL_WARNING: False
+  # we set a default timeout for the entire caching
+  # to 15minutes
+  CACHE_DEFAULT_TIMEOUT: 900
 
 DEVELOPMENT: &development
   <<: *common
@@ -37,5 +43,7 @@ PRODUCTION: &production
   <<: *common
   CELERY_BROKER_URL: amqp://guest:guest@broker:5672//
   CELERY_RESULT_BACKEND: 'rpc://'
-  CELERY_RESULT_PERSISTENT: False  
+  CELERY_RESULT_PERSISTENT: False
   SQLALCHEMY_DATABASE_URI: "postgresql://postgres@db/beavy"
+  CACHE_TYPE: redis
+  CACHE_REDIS_URL: redis://localhost:6379/2

--- a/beavy/requirements/base.txt
+++ b/beavy/requirements/base.txt
@@ -35,6 +35,7 @@ Flask-Security==1.7.4
 flask-social-blueprint==0.7
 Flask-SQLAlchemy==2.0
 Flask-WTF==0.12
+Flask-Cache==0.13.1
 future==0.15.2
 gnureadline==6.3.3
 google-api-python-client==1.4.2

--- a/beavy/utils/__init__.py
+++ b/beavy/utils/__init__.py
@@ -8,8 +8,10 @@ from functools import wraps
 import importlib
 
 
-API_MIMETYPES = ('application/json',
-                 'application/vnd.api+json')
+API_MIMETYPES = set((
+                    'application/json',
+                    'application/vnd.api+json'
+                    ))
 
 
 def load_modules_and_app(app):
@@ -47,8 +49,7 @@ def api_only(fn):
     return wrapped
 
 
-def fallbackRender(template, key=None, nativeTypes=API_MIMETYPES):
-    nativeTypes = set(nativeTypes)
+def fallbackRender(template, key=None):
 
     def wrapper(fn):
         @wraps(fn)
@@ -60,7 +61,7 @@ def fallbackRender(template, key=None, nativeTypes=API_MIMETYPES):
             data, code, headers = unpack(resp)
 
             accepted = set(request.accept_mimetypes.values())
-            if len(accepted & nativeTypes) or request.args.get("json"):
+            if len(accepted & API_MIMETYPES) or request.args.get("json"):
                 # we've found one, return json
                 if isinstance(data, MarshalResult):
                     data = data.data

--- a/beavy/utils/url_converters.py
+++ b/beavy/utils/url_converters.py
@@ -26,7 +26,7 @@ class ModelConverter(BaseConverter):
         except ValueError:
             pass
 
-        if not getattr(cls, "__LOOKUP_ATTRS__"):
+        if not getattr(cls, "__LOOKUP_ATTRS__", False):
             abort(404)
 
         return cls.query.filter(or_(*[getattr(cls, key) == value

--- a/beavy/views/lists/latest.py
+++ b/beavy/views/lists/latest.py
@@ -2,11 +2,12 @@ from beavy.blueprints import lists_bp
 from beavy.models.object import Object
 from beavy.schemas.object import objects_paged
 from beavy.utils import fallbackRender, as_page
-
+from beavy.common.rate_limits import rate_limit
 from sqlalchemy import desc
 
 
 @lists_bp.route("latest/")
+@rate_limit("2/second; 100/minute; 1000/hour; 1000/day")
 @fallbackRender('home.html')
 def latest():
     query = Object.query.by_capability('listed', aborting=False

--- a/beavy_apps/minima/tests/config.yml
+++ b/beavy_apps/minima/tests/config.yml
@@ -4,6 +4,7 @@ MODULES:
  - comments
  - likes
  - private_messaging
+ - url_extractor
 
 APP: 'minima'
 

--- a/beavy_modules/url_extractor/README.adoc
+++ b/beavy_modules/url_extractor/README.adoc
@@ -1,0 +1,14 @@
+= Beavy Url Extractor
+
+A backend (worker) module extracting information from URLs given.
+
+Extracts information using
+
+ - link:https://lassie.readthedocs.org/en/latest/[Lassie]
+ - link:https://github.com/rafaelmartins/pyoembed[PyOEmbed]
+ 
+== Configuration
+
+Add ` url_extractor ` to your list of modules in the `$ROOT/config.yaml`
+
+== Usage

--- a/beavy_modules/url_extractor/__init__.py
+++ b/beavy_modules/url_extractor/__init__.py
@@ -1,0 +1,6 @@
+from .blueprint import blueprint
+from .views import *
+
+def init_app(app):
+    app.register_blueprint(blueprint,
+            url_prefix=app.config.get('URL_EXTRACTOR_URL', '/'))

--- a/beavy_modules/url_extractor/blueprint.py
+++ b/beavy_modules/url_extractor/blueprint.py
@@ -1,0 +1,4 @@
+from flask import Blueprint
+
+blueprint = Blueprint('url_extractor', __name__,
+                      template_folder='templates')

--- a/beavy_modules/url_extractor/lib.py
+++ b/beavy_modules/url_extractor/lib.py
@@ -1,9 +1,57 @@
-import lassie
+
 from pyembed.core import PyEmbed
 
 from beavy.app import cache
 
+from lassie import Lassie
+import re
+
+# lassie by default isn't extensive enough for us
+# configure it so that it is.
+
+from lassie.filters import FILTER_MAPS
+FILTER_MAPS['meta']['open_graph']['map'].update({
+    # general
+    "og:type": "type",
+    "og:site_name": "site_name",
+})
+
+FILTER_MAPS['meta']['generic']['pattern'] = re.compile(r"^(description|keywords|title|author|article:|music:|video:|book:)", re.I)
+FILTER_MAPS['meta']['generic']['map'].update({
+    # articles
+    "article:published_time": "published_time",
+    "article:modified_time": "modified_time",
+    "article:expiration_time": "expiration_time",
+    "article:section": "section",
+    "article:section_url": "section_url",
+
+    # music
+    "music:duration": "duration",
+    "music:release_date": "release_date",
+
+    # video
+    "video:duration": "duration",
+    "video:release_date": "release_date",
+
+    # author
+    "author": "author",
+
+    # book
+    "book:author": "author",
+    "book:isbn": "isbn",
+    "book:release_date": "release_date",
+})
+
+# general configuration
 pyembed = PyEmbed()
+
+lassie = Lassie()
+lassie.request_opts = {
+    'headers':{
+        # tell Lassie to tell others it is facebook
+        'User-Agent': 'facebookexternalhit/1.1'
+    }
+}
 
 @cache.memoize()
 def extract_info(url):
@@ -12,4 +60,4 @@ def extract_info(url):
 
 @cache.memoize()
 def extract_oembed(url, **kwargs):
-    return pyembed.embed('http://www.youtube.com/watch?v=_PEdPBEpQfY', **kwargs)
+    return pyembed.embed(url, **kwargs)

--- a/beavy_modules/url_extractor/lib.py
+++ b/beavy_modules/url_extractor/lib.py
@@ -1,0 +1,15 @@
+import lassie
+from pyembed.core import PyEmbed
+
+from beavy.app import cache
+
+pyembed = PyEmbed()
+
+@cache.memoize()
+def extract_info(url):
+    return lassie.fetch(url)
+
+
+@cache.memoize()
+def extract_oembed(url, **kwargs):
+    return pyembed.embed('http://www.youtube.com/watch?v=_PEdPBEpQfY', **kwargs)

--- a/beavy_modules/url_extractor/lib/__init__.py
+++ b/beavy_modules/url_extractor/lib/__init__.py
@@ -1,11 +1,7 @@
 
 from beavy.app import cache
-from .fetching import lassie, pyembed
+from .fetching import lassie
 
 @cache.memoize()
 def extract_info(url):
     return lassie.fetch(url)
-
-@cache.memoize()
-def extract_oembed(url, **kwargs):
-    return pyembed.embed(url, **kwargs)

--- a/beavy_modules/url_extractor/lib/__init__.py
+++ b/beavy_modules/url_extractor/lib/__init__.py
@@ -1,7 +1,7 @@
 
 from beavy.app import cache
-from .fetching import lassie
+from .fetching import extractor
 
 @cache.memoize()
 def extract_info(url):
-    return lassie.fetch(url)
+    return extractor.fetch(url)

--- a/beavy_modules/url_extractor/lib/__init__.py
+++ b/beavy_modules/url_extractor/lib/__init__.py
@@ -1,0 +1,11 @@
+
+from beavy.app import cache
+from .fetching import lassie, pyembed
+
+@cache.memoize()
+def extract_info(url):
+    content = lassie.fetch(url)
+
+@cache.memoize()
+def extract_oembed(url, **kwargs):
+    return pyembed.embed(url, **kwargs)

--- a/beavy_modules/url_extractor/lib/__init__.py
+++ b/beavy_modules/url_extractor/lib/__init__.py
@@ -4,7 +4,7 @@ from .fetching import lassie, pyembed
 
 @cache.memoize()
 def extract_info(url):
-    content = lassie.fetch(url)
+    return lassie.fetch(url)
 
 @cache.memoize()
 def extract_oembed(url, **kwargs):

--- a/beavy_modules/url_extractor/lib/fetching.py
+++ b/beavy_modules/url_extractor/lib/fetching.py
@@ -1,6 +1,6 @@
 from pyembed.core import PyEmbed
 
-from lassie import Lassie
+from lassie.core import Lassie
 import re
 
 # lassie by default isn't extensive enough for us
@@ -42,7 +42,49 @@ FILTER_MAPS['meta']['generic']['map'].update({
 # general configuration
 pyembed = PyEmbed()
 
-lassie = Lassie()
+class AmazonISBNFinder():
+    def _check(self, data):
+        return data.get("type", None) == 'book' and data.get("site_name", "").lower().startswith("amazon.")
+
+    def __call__(self, soup, data, url=None):
+        if not self._check(data): return
+        # amazon hides the ISBN inside the keywords
+        # title + 1 => publisher
+        # title + 2 => ISBN
+        # everything after => categories
+
+        try:
+            title_idx = data["keywords"].index(data['title'])
+            data.update({
+                "authors": data["keywords"][:title_idx],
+                "publisher": data["keywords"][title_idx + 1],
+                "ISBN": data["keywords"][title_idx + 2],
+                "categories": data["keywords"][title_idx + 3:]
+            })
+        except (ValueError, KeyError):
+            # not found. ignored.
+            pass
+
+
+
+class PostProcessingLassie(Lassie):
+
+    POST_PROCESSORS = [
+        AmazonISBNFinder()
+    ]
+
+    def _filter_meta_data(self, source, soup, data, url=None):
+        super(PostProcessingLassie, self)._filter_meta_data(source, soup, data, url=url)
+
+        if source == "generic":
+            # we are in the last generic parsing,
+            # do the post_processing
+            for processor in self.POST_PROCESSORS:
+                processor(soup, data, url=url)
+
+        return data
+
+lassie = PostProcessingLassie()
 lassie.request_opts = {
     'headers':{
         # tell Lassie to tell others it is facebook

--- a/beavy_modules/url_extractor/lib/fetching.py
+++ b/beavy_modules/url_extractor/lib/fetching.py
@@ -190,6 +190,17 @@ class MediaWikiExtractor:
             if first_para:
                 data["description"] = first_para.text
 
+
+class YoutubeExtractor:
+
+    def __call__(self, soup, data, url=None):
+        if not _matches(data, type="video", site_name="YouTube"):
+            return
+
+        baseContent = soup.find(id="eow-description")
+        if baseContent:
+            data['full_description'] = baseContent.text
+
 class BloggerExtractor:
 
     def __call__(self, soup, data, url=None):
@@ -255,6 +266,7 @@ class PostProcessingLassie(Lassie):
         # Specific Platforms:
         AmazonISBNFinder(),
         SoundcloudInfoExtractor(),
+        YoutubeExtractor(),
 
         # If we don't find anything, extract from content
         SimpleInfoFallbackExtractor()

--- a/beavy_modules/url_extractor/lib/fetching.py
+++ b/beavy_modules/url_extractor/lib/fetching.py
@@ -1,5 +1,3 @@
-from pyembed.core import PyEmbed
-
 from lassie.core import Lassie
 from lassie.compat import str
 
@@ -50,9 +48,6 @@ FILTER_MAPS['meta']['open_graph']['map'].update({
     "book:isbn": "isbn",
     "book:release_date": "release_date",
 })
-
-# general configuration
-pyembed = PyEmbed()
 
 def _matches(data, **kwargs):
     for key, match in kwargs.items():
@@ -188,6 +183,7 @@ class PostProcessingLassie(Lassie):
 
         return data
 
+# this is what is exported
 lassie = PostProcessingLassie()
 lassie.request_opts = {
     'headers':{

--- a/beavy_modules/url_extractor/lib/fetching.py
+++ b/beavy_modules/url_extractor/lib/fetching.py
@@ -1,20 +1,32 @@
 from pyembed.core import PyEmbed
 
 from lassie.core import Lassie
+from lassie.compat import str
+
+import requests
 import re
 
 # lassie by default isn't extensive enough for us
 # configure it so that it is.
 
 from lassie.filters import FILTER_MAPS
+FILTER_MAPS['meta']['open_graph']['pattern'] = re.compile(r"^(og:|author:|article:|music:|video:|book:)", re.I)
 FILTER_MAPS['meta']['open_graph']['map'].update({
     # general
     "og:type": "type",
     "og:site_name": "site_name",
-})
 
-FILTER_MAPS['meta']['generic']['pattern'] = re.compile(r"^(description|keywords|title|author|article:|music:|video:|book:)", re.I)
-FILTER_MAPS['meta']['generic']['map'].update({
+    # video
+    # LIST, and we don't have list support atm
+    # "og:video:tag": "tag",
+
+    # at least used by meetup.com!
+    "og:country-name": "country_name",
+    "og:locality": "locality",
+    "og:latitude": "latitude",
+    "og:longitude": "longitude",
+    "og:locale": "locale",
+
     # articles
     "article:published_time": "published_time",
     "article:modified_time": "modified_time",
@@ -42,12 +54,31 @@ FILTER_MAPS['meta']['generic']['map'].update({
 # general configuration
 pyembed = PyEmbed()
 
-class AmazonISBNFinder():
-    def _check(self, data):
-        return data.get("type", None) == 'book' and data.get("site_name", "").lower().startswith("amazon.")
+def _matches(data, **kwargs):
+    for key, match in kwargs.items():
+        try:
+            given_value = data[key]
+        except KeyError:
+            return False
+        else:
+            if isinstance(match, re._pattern_type):
+                if not match.match(given_value):
+                    return False
+            elif callable(match):
+                if not match(given_value):
+                    return False
+            else:
+                if match != given_value:
+                    return False
+    return True
+
+class AmazonISBNFinder:
 
     def __call__(self, soup, data, url=None):
-        if not self._check(data): return
+        if not _matches(data,
+            type='book',
+            site_name=lambda x: x.lower().startswith("amazon")
+        ): return
         # amazon hides the ISBN inside the keywords
         # title + 1 => publisher
         # title + 2 => ISBN
@@ -65,12 +96,85 @@ class AmazonISBNFinder():
             # not found. ignored.
             pass
 
+class AlternateFinder:
+    def __call__(self, soup, data, url=None):
+        map = lambda link: (link.get("type") or link.get("media") or link.get("hreflang") or link.get("href").split("://", 1)[0] , link.get("href"))
+        data["alternates"] = target = {}
+
+        for name in ("alternate", "alternative"):
+            target.update(dict([ map(link)
+                for link in soup.find_all('link', {'rel': name}) ]))
+
+class OEmbedExtractor:
+    REMAP = ["author_name", "author_url", "licence", "licence_url", "url", "title", "type"]
+
+    def __call__(self, soup, data, url=None):
+        try:
+            link = data["alternates"]["application/json+oembed"]
+        except KeyError:
+            # inofficial link
+            try:
+                link  = data["alternates"]["text/json+oembed"]
+            except KeyError:
+                return
+
+        data["oembed"] = requests.Session().get(link).json()
+
+        for key in self.REMAP:
+            if key not in data['oembed']:
+                continue
+            if not data.get(key, False):
+                data[key] = data["oembed"][key]
+
+class SoundcloudInfoExtractor:
+    MATCHER = re.compile(r"^soundcloud:")
+    def __call__(self, soup, data, url=None):
+        if not _matches(data, type="soundcloud:sound", site_name="SoundCloud"):
+            return
+
+        data["soundcloud"] = dict([ (m.get("property")[11:], m.get("content"))
+            for m in soup.find_all('meta', {'property': self.MATCHER}) ])
+
+class ArticleMetaExtractor:
+    def __call__(self, soup, data, url=None):
+        if not _matches(data, type="article"):
+            return
+
+        if not data.get("copyright", False):
+            copy = soup.find("meta", {'name': "copyright"})
+            if copy:
+                data["copyright"] = copy.get("content")
+
+        if not data.get("publisher", False):
+            tag = soup.find("meta", {'name': "cre"})
+
+            if tag:
+                data["publisher"] = tag.get("content")
+            elif "copyright" in data:
+                data["publisher"] = data["copyright"]
+
+
+
+        if not data.get("genre", False):
+            genre = soup.find("meta", {'itemprop': "genre"})
+            if genre:
+                data["genre"] = genre.get("content")
 
 
 class PostProcessingLassie(Lassie):
 
     POST_PROCESSORS = [
-        AmazonISBNFinder()
+        # Generic Finders
+        AlternateFinder(),
+        OEmbedExtractor(), # OEmbed only works after Alternate!
+
+        # Mid specific:
+        # Newspapers (like NYTimes):
+        ArticleMetaExtractor(),
+
+        # Specific Platforms:
+        AmazonISBNFinder(),
+        SoundcloudInfoExtractor()
     ]
 
     def _filter_meta_data(self, source, soup, data, url=None):

--- a/beavy_modules/url_extractor/lib/fetching.py
+++ b/beavy_modules/url_extractor/lib/fetching.py
@@ -1,7 +1,4 @@
-
 from pyembed.core import PyEmbed
-
-from beavy.app import cache
 
 from lassie import Lassie
 import re
@@ -52,12 +49,3 @@ lassie.request_opts = {
         'User-Agent': 'facebookexternalhit/1.1'
     }
 }
-
-@cache.memoize()
-def extract_info(url):
-    return lassie.fetch(url)
-
-
-@cache.memoize()
-def extract_oembed(url, **kwargs):
-    return pyembed.embed(url, **kwargs)

--- a/beavy_modules/url_extractor/lib/fetching.py
+++ b/beavy_modules/url_extractor/lib/fetching.py
@@ -272,8 +272,8 @@ class PostProcessingLassie(Lassie):
         return data
 
 # this is what is exported
-lassie = PostProcessingLassie()
-lassie.request_opts = {
+extractor = PostProcessingLassie()
+extractor.request_opts = {
     'headers':{
         # tell Lassie to tell others it is facebook
         'User-Agent': 'facebookexternalhit/1.1'

--- a/beavy_modules/url_extractor/lib/fetching_test.py
+++ b/beavy_modules/url_extractor/lib/fetching_test.py
@@ -1,0 +1,532 @@
+import pytest
+from .fetching import extractor
+
+class Number:
+    def __init__(self, num=0):
+        self.num = num
+    def __eq__(self, other):
+        if not isinstance(other, int):
+            other = int(other)
+        return self.num <= other
+
+class StartsWith:
+    def __init__(self, str):
+        self.str = str
+    def __eq__(self, other):
+        return other.startswith(self.str)
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_blogger_example():
+    assert extractor.fetch("http://buzz.blogger.com/2015/09/https-support-coming-to-blogspot.html") == {
+        "alternates": {
+            "application/atom+xml": "http://buzz.blogger.com/feeds/653731578225022752/comments/default",
+            "application/rss+xml": "http://buzz.blogger.com/feeds/posts/default?alt=rss"
+        },
+        "description": "This morning we posted an update about Blogspot to Google\u2019s Security Blog https://googleonlinesecurity.blogspot.com/2015/09/https-support-coming-to-blogspot.html. Since 2008, we've worked to encrypt the connections between our users and Google servers. Over the years\u00a0we've announced that Search, Gmail, Drive, and many other products have encrypted connections by default, and most recently, we've made a similar announcement for our ads products. In this same vein, today we're expanding on the HTT",
+        "generator": "blogger",
+        "images": [
+            {
+                "src": "http://2.bp.blogspot.com/-i2Zz0p3UoX4/VgsPJGm9_fI/AAAAAAAAROA/HoN3rq-s93U/s640/unnamed.png",
+                "type": "contentImage"
+            },
+            {
+                "src": "http://buzz.blogger.com/favicon.ico",
+                "type": "favicon"
+            }
+        ],
+        "locale": "en_US",
+        "title": "Blogger Buzz: HTTPS support coming to Blogspot",
+        "type": "article:blog",
+        "url": "http://buzz.blogger.com/2015/09/https-support-coming-to-blogspot.html",
+        "videos": []
+    }
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_amazon_example():
+    assert extractor.fetch("http://www.amazon.de/Fall-Jane-Eyre-Roman-Unterhaltung/dp/3423212934/ref=sr_1_1?ie=UTF8") == {
+        "ISBN": "3423212934",
+        "alternates": {},
+        "authors": [
+            "Jasper Fforde",
+            "Lorenz Stern"
+        ],
+        "categories": [
+            "Belletristik / Science Fiction / Fantasy",
+            "England",
+            "Englische Belletristik",
+            "Roman",
+            "Erz\u00e4hlung",
+            "Fantasy",
+            "Belletristik / Fantastische Literatur",
+            "Belletristik in \u00dcbersetzung",
+            "Comic (Humor) Fantasy",
+            "Kriminalromane & Mystery: weibliche Ermittler"
+        ],
+        "description": "Der Fall Jane Eyre: Roman (dtv Unterhaltung)",
+        "images": [
+            {
+                "src": "http://ecx.images-amazon.com/images/I/51oEhE2AYEL._SS500_.jpg",
+                "type": "og:image"
+            }
+        ],
+        "keywords": [
+            "Jasper Fforde",
+            "Lorenz Stern",
+            "Der Fall Jane Eyre: Roman (dtv Unterhaltung)",
+            "Deutscher Taschenbuch Verlag",
+            "3423212934",
+            "Belletristik / Science Fiction / Fantasy",
+            "England",
+            "Englische Belletristik",
+            "Roman",
+            "Erz\u00e4hlung",
+            "Fantasy",
+            "Belletristik / Fantastische Literatur",
+            "Belletristik in \u00dcbersetzung",
+            "Comic (Humor) Fantasy",
+            "Kriminalromane & Mystery: weibliche Ermittler"
+        ],
+        "publisher": "Deutscher Taschenbuch Verlag",
+        "site_name": "Amazon.de",
+        "title": "Der Fall Jane Eyre: Roman (dtv Unterhaltung)",
+        "type": "book",
+        "url": "http://www.amazon.de/dp/3423212934/ref=tsm_1_fb_lk",
+        "videos": []
+    }
+
+
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_wikipedia_example():
+    assert extractor.fetch("https://en.wikipedia.org/wiki/Polygon") == {
+        "alternates": {
+            "android-app": "android-app://org.wikipedia/http/en.m.wikipedia.org/wiki/Polygon",
+            "application/atom+xml": "/w/index.php?title=Special:RecentChanges&feed=atom",
+            "application/x-wiki": "/w/index.php?title=Polygon&action=edit"
+        },
+        "description": "In elementary geometry, a polygon /\u02c8p\u0252l\u026a\u0261\u0252n/ is a plane figure that is bounded by a finite chain of straight line segments closing in a loop to form a closed chain or circuit. These segments are called its edges or sides, and the points where two edges meet are the polygon's vertices (singular: vertex) or corners. The interior of the polygon is sometimes called its body. An n-gon is a polygon with n sides. A polygon is a 2-dimensional example of the more general polytope in any number of dimensions.",
+        "generator": StartsWith("MediaWiki"),
+        "images": [
+            {
+                "src": "//upload.wikimedia.org/wikipedia/commons/thumb/1/1f/Assorted_polygons.svg/400px-Assorted_polygons.svg.png",
+                "type": "contentImage"
+            },
+            {
+                "src": "https://en.wikipedia.org/static/favicon/wikipedia.ico",
+                "type": "favicon"
+            }
+        ],
+        "locale": "en_US",
+        "site_name": "From Wikipedia, the free encyclopedia",
+        "title": "Polygon",
+        "type": "article:wiki",
+        "url": "https://en.wikipedia.org/wiki/Polygon",
+        "videos": []
+    }
+
+
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_meetup_com_event_example():
+    assert extractor.fetch("http://www.meetup.com/opentechschool-berlin/events/226129991/") == {
+        "alternates": {
+            "de": "http://www.meetup.com/de/opentechschool-berlin/events/226129991/",
+            "en": "http://www.meetup.com/opentechschool-berlin/events/226129991/",
+            "es": "http://www.meetup.com/es/opentechschool-berlin/events/226129991/",
+            "fr": "http://www.meetup.com/fr/opentechschool-berlin/events/226129991/",
+            "it": "http://www.meetup.com/it/opentechschool-berlin/events/226129991/",
+            "ja": "http://www.meetup.com/ja/opentechschool-berlin/events/226129991/",
+            "pt": "http://www.meetup.com/pt/opentechschool-berlin/events/226129991/",
+            "x-default": "http://www.meetup.com/opentechschool-berlin/events/226129991/"
+        },
+        "country_name": "de",
+        "description": "ABOUT:The meet-up is all about Ruby and Rails (but also about all the other things you can do with Ruby).We are a friendly group that meets every monday at seven o'clock to learn together and work o",
+        "images": [
+            {
+                "src": "http://photos3.meetupstatic.com/photos/event/2/6/1/8/highres_162009752.jpeg",
+                "type": "og:image"
+            }
+        ],
+        "keywords": [
+            "Germany",
+            "Berlin",
+            "softwaredev",
+            "Learners",
+            "group",
+            "club",
+            "event",
+            "community",
+            "local",
+            "networking",
+            "meet",
+            "sharing",
+            "Meetup"
+        ],
+        "latitude": "52.52",
+        "locale": "en_US",
+        "locality": "Berlin",
+        "longitude": "13.38",
+        "site_name": "Meetup",
+        "title": "OpenTechSchool Berlin",
+        "type": "activity",
+        "url": "http://www.meetup.com/opentechschool-berlin/events/226129991/",
+        "videos": []
+    }
+
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_soundcloud_song_example():
+    assert extractor.fetch("https://soundcloud.com/bassmelodie/bassmelodie-wintermelancholie") == {
+        "alternates": {
+            "android-app": "android-app://com.soundcloud.android/soundcloud/sounds:181196205",
+            "ios-app": "ios-app://336353151/soundcloud/sounds:181196205",
+            "only screen and (max-width: 640px)": "https://m.soundcloud.com/bassmelodie/bassmelodie-wintermelancholie",
+            "text/json+oembed": "https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fbassmelodie%2Fbassmelodie-wintermelancholie&format=json",
+            "text/xml+oembed": "https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fbassmelodie%2Fbassmelodie-wintermelancholie&format=xml"
+        },
+        "author_name": "Bassmelodie",
+        "author_url": "https://soundcloud.com/bassmelodie",
+        "description": "Winter has its ups and downs... Lots of people are alone and don't have anyone whom they are able to share their feelings and emotions with. Sometimes it's worth to think not only about oneself. Ther",
+        "images": [
+            {
+                "height": 500,
+                "src": "https://i1.sndcdn.com/artworks-000100023660-j8gjf5-t500x500.jpg",
+                "type": "og:image",
+                "width": 500
+            },
+            {
+                "src": "https://a-v2.sndcdn.com/assets/images/sc-icons/favicon-2cadd14b.ico",
+                "type": "favicon"
+            }
+        ],
+        "keywords": [
+            "record",
+            "sounds",
+            "share",
+            "sound",
+            "audio",
+            "tracks",
+            "music",
+            "soundcloud"
+        ],
+        "locale": "en_US",
+        "oembed": {
+            "author_name": "Bassmelodie",
+            "author_url": "https://soundcloud.com/bassmelodie",
+            "description": "Winter has its ups and downs... \nLots of people are alone and don't have anyone whom they are able to share their feelings and emotions with. Sometimes it's worth to think not only about oneself. There are plenty of people out there who don't have anyone and who are alone. But there are also people who allegedly have everything they need. Nevertheless, they get a feeling of deep melancholy. \nYou can never be sure that such emotions will once hit you.\nThis set is dedicated to all those people...",
+            "height": 400,
+            "html": "<iframe width=\"100%\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F181196205&show_artwork=true\"></iframe>",
+            "provider_name": "SoundCloud",
+            "provider_url": "http://soundcloud.com",
+            "thumbnail_url": "http://i1.sndcdn.com/artworks-000100023660-j8gjf5-t500x500.jpg",
+            "title": "Bassmelodie | Wintermelancholie by Bassmelodie",
+            "type": "rich",
+            "version": 1.0,
+            "width": "100%"
+        },
+        "site_name": "SoundCloud",
+        "soundcloud": {
+            "comments_count": Number(200),
+            "download_count": Number(0),
+            "like_count": Number(4052),
+            "play_count": Number(73265),
+            "user": "https://soundcloud.com/bassmelodie"
+        },
+        "title": "Bassmelodie | Wintermelancholie",
+        "type": "soundcloud:sound",
+        "url": "https://soundcloud.com/bassmelodie/bassmelodie-wintermelancholie",
+        "videos": []
+    }
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_nytimes_example():
+    assert extractor.fetch("http://www.nytimes.com/2015/11/15/arts/music/le1f-speaks-out-like-his-fearless-models-on-riot-boi.html") == {
+        "alternates": {
+            "android-app": "android-app://com.nytimes.android/nytimes/reader/id/100000004021164",
+            "http": "http://mobile.nytimes.com/2015/11/15/arts/music/le1f-speaks-out-like-his-fearless-models-on-riot-boi.html"
+        },
+        "description": "The rapper talks about a range of influences he drew on \u2014 Amanda Blank, M.I.A., Dev Hynes and others \u2014 in addressing misogyny, homophobia and more in his first full-length album.",
+        "genre": "News",
+        "images": [
+            {
+                "src": "http://static01.nyt.com/images/2015/11/15/arts/15PLAYLIST1/15PLAYLIST1-facebookJumbo.jpg",
+                "type": "og:image"
+            },
+            {
+                "src": "http://static01.nyt.com/favicon.ico",
+                "type": "favicon"
+            }
+        ],
+        "keywords": [
+            "Music",
+            "Rap and Hip-Hop",
+            "Le1f",
+            "Riot Boi (Album Title)",
+            "Discrimination"
+        ],
+        "locale": "en_US",
+        "publisher": "The New York Times",
+        "section": "Music",
+        "section_url": "http://www.nytimes.com/pages/arts/index.html",
+        "title": " Le1f Speaks Out, Like His Fearless Models, on \u2018Riot Boi\u2019",
+        "type": "article",
+        "url": "http://www.nytimes.com/2015/11/15/arts/music/le1f-speaks-out-like-his-fearless-models-on-riot-boi.html",
+        "videos": []
+    }
+
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_zeitDe_example():
+    assert extractor.fetch("http://www.zeit.de/politik/ausland/2015-11/polen-unabhaengigkeit-marsch-nationalisten") == {
+        "alternates": {
+            "application/rss+xml": "http://newsfeed.zeit.de/index"
+        },
+        "description": "Die Unabh\u00e4ngigkeitsparaden in Polen waren einmal bunt und lustig. Das ist vorbei, auch weil der Extremismus in der Politik angekommen ist.",
+        "images": [
+            {
+                "src": "http://www.zeit.de/politik/ausland/2015-11/unabhaengigkeit-parade-polen/wide__1300x731",
+                "type": "og:image"
+            },
+            {
+                "src": "http://www.zeit.de/politik/ausland/2015-11/unabhaengigkeit-parade-polen/wide__1300x731",
+                "type": "twitter:image"
+            },
+            {
+                "src": "http://images.zeit.de/static/img/favicon.ico",
+                "type": "favicon"
+            }
+        ],
+        "keywords": [
+            "Polen",
+            "Nationalismus",
+            "Rechtsextremismus",
+            "Jaros\u0142aw Kaczy\u0144ski"
+        ],
+        "locale": "de_DE",
+        "site_name": "ZEIT ONLINE",
+        "title": "Radikal ist in Polen zum Mainstream geworden",
+        "type": "article",
+        "url": "http://www.zeit.de/politik/ausland/2015-11/polen-unabhaengigkeit-marsch-nationalisten",
+        "videos": []
+    }
+
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_flickr_image_example():
+    assert extractor.fetch("https://www.flickr.com/photos/wbaiv/4332173964/in/photolist-7APwoy") == {
+        "alternates": {
+            "application/json+oembed": "https://www.flickr.com/services/oembed?url=https://www.flickr.com/photos/wbaiv/4332173964&format=json",
+            "text/xml+oembed": "https://www.flickr.com/services/oembed?url=https://www.flickr.com/photos/wbaiv/4332173964&format=xml"
+        },
+        "author_name": "wbaiv",
+        "author_url": "https://www.flickr.com/photos/wbaiv/",
+        "description": "This is the nose gear for the City of Everett, with big beavy blocks attached to the airplane to keep it in one place no matter how much the wind blows!  102-0233_IMG",
+        "images": [
+            {
+                "height": 500,
+                "src": "https://c1.staticflickr.com/5/4047/4332173964_e60fa3d95a.jpg",
+                "type": "og:image",
+                "width": 375
+            }
+        ],
+        "locale": "en_US",
+        "oembed": {
+            "author_name": "wbaiv",
+            "author_url": "https://www.flickr.com/photos/wbaiv/",
+            "cache_age": 3600,
+            "flickr_type": "photo",
+            "height": "500",
+            "html": "<a data-flickr-embed=\"true\" href=\"https://www.flickr.com/photos/wbaiv/4332173964/\" title=\"747-100 prototype nose gear by wbaiv, on Flickr\"><img src=\"https://farm5.staticflickr.com/4047/4332173964_e60fa3d95a.jpg\" width=\"375\" height=\"500\" alt=\"747-100 prototype nose gear\"></a><script async src=\"https://embedr.flickr.com/assets/client-code.js\" charset=\"utf-8\"></script>",
+            "license": "Attribution-ShareAlike License",
+            "license_id": "5",
+            "license_url": "https://creativecommons.org/licenses/by-sa/2.0/",
+            "provider_name": "Flickr",
+            "provider_url": "https://www.flickr.com/",
+            "thumbnail_height": 150,
+            "thumbnail_url": "https://farm5.staticflickr.com/4047/4332173964_e60fa3d95a_q.jpg",
+            "thumbnail_width": 150,
+            "title": "747-100 prototype nose gear",
+            "type": "photo",
+            "url": "https://farm5.staticflickr.com/4047/4332173964_e60fa3d95a.jpg",
+            "version": "1.0",
+            "web_page": "https://www.flickr.com/photos/wbaiv/4332173964/",
+            "web_page_short_url": "https://flic.kr/p/7APwoy",
+            "width": "375"
+        },
+        "site_name": "Flickr - Photo Sharing!",
+        "title": "747-100 prototype nose gear",
+        "type": "flickr_photos:photo",
+        "url": "https://www.flickr.com/photos/wbaiv/4332173964/",
+        "videos": []
+    }
+
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_tedCom_example():
+    assert extractor.fetch("http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results") == {
+        "alternates": {
+            "application/json+oembed": "http://www.ted.com/services/v1/oembed.json?url=http%3A%2F%2Fwww.ted.com%2Ftalks%2Fandreas_ekstrom_the_moral_bias_behind_your_search_results",
+            "application/xml+oembed": "http://www.ted.com/services/v1/oembed.xml?url=http%3A%2F%2Fwww.ted.com%2Ftalks%2Fandreas_ekstrom_the_moral_bias_behind_your_search_results",
+            "en": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results?language=en",
+            "pt-br": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results?language=pt-br",
+            "x-default": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results"
+        },
+        "author_name": "Andreas Ekstr\u00f6m",
+        "author_url": "http://www.ted.com/speakers/andreas_ekstrom",
+        "description": "Search engines have become our most trusted sources of information and arbiters of truth. But can we ever get an unbiased search result? Swedish author and journalist Andreas Ekstr\u00f6m argues that such a thing is a philosophical impossibility. In this thoughtful talk, he calls on us to strengthen the bonds between technology and the humanities, and he reminds us that behind every algorithm is a set of personal beliefs that no code can ever completely eradicate.",
+        "duration": "558",
+        "images": [
+            {
+                "height": 550,
+                "secure_src": "https://tedcdnpi-a.akamaihd.net/r/tedcdnpe-a.akamaihd.net/images/ted/90eeddc216ca86ad2fbf99d0823a39fe681e7513_2880x1620.jpg?c=1050%2C550&w=1050",
+                "src": "https://tedcdnpi-a.akamaihd.net/r/tedcdnpe-a.akamaihd.net/images/ted/90eeddc216ca86ad2fbf99d0823a39fe681e7513_2880x1620.jpg?c=1050%2C550&w=1050",
+                "type": "og:image",
+                "width": 1050
+            },
+            {
+                "src": "https://tedcdnpa-a.akamaihd.net/favicon.svg",
+                "type": "favicon"
+            },
+            {
+                "src": "https://tedcdnpa-a.akamaihd.net/favicon.ico",
+                "type": "favicon"
+            }
+        ],
+        "keywords": [
+            "TED",
+            "talks",
+            "Google",
+            "Internet",
+            "TEDx",
+            "algorithm",
+            "communication",
+            "computers",
+            "decision-making",
+            "society",
+            "software",
+            "technology",
+            "web"
+        ],
+        "locale": "en_US",
+        "oembed": {
+            "author_name": "Andreas Ekstr\u00f6m",
+            "author_url": "http://www.ted.com/speakers/andreas_ekstrom",
+            "description": "Search engines have become our most trusted sources of information and arbiters of truth. But can we ever get an unbiased search result? Swedish author and journalist Andreas Ekstr\u00f6m argues that such a thing is a philosophical impossibility. In this thoughtful talk, he calls on us to strengthen the bonds between technology and the humanities, and he reminds us that behind every algorithm is a set of personal beliefs that no code can ever completely eradicate.",
+            "height": 315,
+            "html": "<iframe src=\"https://embed-ssl.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results.html\" width=\"560\" height=\"315\" frameborder=\"0\" scrolling=\"no\" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>",
+            "provider_name": "TED",
+            "provider_url": "http://ted.com",
+            "thumbnail_height": 180,
+            "thumbnail_url": "http://tedcdnpe-a.akamaihd.net/images/ted/1ffc899e31b37f85948bea87dd18710f1a847b4d_240x180.jpg?lang=en",
+            "thumbnail_width": 240,
+            "title": "Andreas Ekstr\u00f6m: The moral bias behind your search results",
+            "type": "video",
+            "url": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results",
+            "version": "1.0",
+            "width": 560
+        },
+        "release_date": "1447173342",
+        "title": "The moral bias behind your search results",
+        "type": "video.other",
+        "url": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results",
+        "videos": []
+    }
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_youtube_example():
+    assert extractor.fetch("https://www.youtube.com/watch?v=SQ5wYZqHQGo?t=505") == {
+        "alternates": {
+            "android-app": "android-app://com.google.android.youtube/http/www.youtube.com/watch?v=SQ5wYZqHQGo",
+            "application/json+oembed": StartsWith("http://www.youtube.com/oembed"),
+            "handheld": "http://m.youtube.com/watch?v=SQ5wYZqHQGo",
+            "ios-app": "ios-app://544007664/vnd.youtube/www.youtube.com/watch?v=SQ5wYZqHQGo",
+            "only screen and (max-width: 640px)": "http://m.youtube.com/watch?v=SQ5wYZqHQGo",
+            "text/xml+oembed": StartsWith("http://www.youtube.com/oembed")
+        },
+        "author_name": "O'Reilly",
+        "author_url": "https://www.youtube.com/user/OreillyMedia",
+        "description": "From the 2015 Velocity Conference in New York: I\u2019m going to talk about cognitive bias in operations land. I will go through two examples. The first example i...",
+        "images": [
+            {
+                "src": "https://i.ytimg.com/vi/SQ5wYZqHQGo/hqdefault.jpg",
+                "type": "og:image"
+            },
+            {
+                "src": "https://i.ytimg.com/vi/SQ5wYZqHQGo/hqdefault.jpg",
+                "type": "twitter:image"
+            },
+            {
+                "src": "https://s.ytimg.com/yts/img/favicon-vflz7uhzw.ico",
+                "type": "favicon"
+            },
+            {
+                "src": "https://s.ytimg.com/yts/img/favicon_32-vfl8NGn4k.png",
+                "type": "favicon"
+            },
+            {
+                "src": "https://s.ytimg.com/yts/img/favicon_48-vfl1s0rGh.png",
+                "type": "favicon"
+            },
+            {
+                "src": "https://s.ytimg.com/yts/img/favicon_96-vfldSA3ca.png",
+                "type": "favicon"
+            },
+            {
+                "src": "https://s.ytimg.com/yts/img/favicon_144-vflWmzoXw.png",
+                "type": "favicon"
+            }
+        ],
+        "keywords": [
+            "O'Reilly Media (Publisher)",
+            "digitalocean",
+            "velocity new york",
+            "velocity 2015",
+            "velocity conference",
+            "Bryan Liles",
+            "Operating System (Software Genre)",
+            "cognitive bias"
+        ],
+        "locale": "de_DE",
+        "oembed": {
+            "author_name": "O'Reilly",
+            "author_url": "https://www.youtube.com/user/OreillyMedia",
+            "height": 270,
+            "html": "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/SQ5wYZqHQGo?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>",
+            "provider_name": "YouTube",
+            "provider_url": "https://www.youtube.com/",
+            "thumbnail_height": 360,
+            "thumbnail_url": "https://i.ytimg.com/vi/SQ5wYZqHQGo/hqdefault.jpg",
+            "thumbnail_width": 480,
+            "title": "The Darker Side of Tech - Bryan Liles keynote",
+            "type": "video",
+            "version": "1.0",
+            "width": 480
+        },
+        "site_name": "YouTube",
+        "title": "The Darker Side of Tech - Bryan Liles keynote",
+        "type": "video",
+        "url": "https://www.youtube.com/watch?v=SQ5wYZqHQGo",
+        "videos": [
+            {
+                "height": 720,
+                "secure_src": "https://www.youtube.com/v/SQ5wYZqHQGo?version=3&autohide=1",
+                "src": "http://www.youtube.com/v/SQ5wYZqHQGo?version=3&autohide=1",
+                "width": 1280
+            },
+            {
+                "height": 720,
+                "src": "https://www.youtube.com/embed/SQ5wYZqHQGo",
+                "width": 1280
+            }
+        ]
+    }

--- a/beavy_modules/url_extractor/lib/fetching_test.py
+++ b/beavy_modules/url_extractor/lib/fetching_test.py
@@ -243,6 +243,30 @@ def test_soundcloud_song_example():
         "videos": []
     }
 
+
+@pytest.mark.slow
+@pytest.mark.external
+def test_slidesCom_example():
+    assert extractor.fetch("http://slides.com/benjaminkampmann/component-oriented-ux/") == {
+        "alternates": {},
+        "description": "Understanding UI as reusable components and building it in a modular way are the new black in web development. But how exactly do you apply these latest technologies while still allowing overall themes and customization as we are used to? In this case study, we will look under the hood of beavy to understand how it uses CSS Modules and React to marry having highly complex, reusable UI-components and ensuring they can be completely customized at the same time. And what that means for the overall design process. --- This talk has been presented at UpFront #62, Nov 10th 2015, Berlin: http://www.meetup.com/up-front-ug/events/226053994/",
+        "images": [
+            {
+                "src": "https://s3.amazonaws.com/media-p.slid.es/thumbnails/secure/69e3a7/decks.jpg",
+                "type": "og:image"
+            },
+            {
+                "src": "https://s3.amazonaws.com/media-p.slid.es/thumbnails/secure/69e3a7/decks.jpg",
+                "type": "twitter:image"
+            }
+        ],
+        "site_name": "Slides",
+        "title": "Component-Oriented UX For The Win\u2026 But How? by Benjamin Kampmann",
+        "type": "article",
+        "url": "http://slides.com/benjaminkampmann/component-oriented-ux",
+        "videos": []
+    }
+
 @pytest.mark.slow
 @pytest.mark.external
 def test_nytimes_example():
@@ -266,9 +290,9 @@ def test_nytimes_example():
         "keywords": [
             "Music",
             "Rap and Hip-Hop",
-            "Le1f",
             "Riot Boi (Album Title)",
-            "Discrimination"
+            "Discrimination",
+            "Diouf  Khalif (Le1f) (1989- )"
         ],
         "locale": "en_US",
         "publisher": "The New York Times",
@@ -311,7 +335,7 @@ def test_zeitDe_example():
         ],
         "locale": "de_DE",
         "site_name": "ZEIT ONLINE",
-        "title": "Radikal ist in Polen zum Mainstream geworden",
+        "title": "Unabh\u00e4ngigkeitstag: Radikal ist in Polen zum Mainstream geworden |\u00a0ZEIT ONLINE",
         "type": "article",
         "url": "http://www.zeit.de/politik/ausland/2015-11/polen-unabhaengigkeit-marsch-nationalisten",
         "videos": []
@@ -456,6 +480,7 @@ def test_youtube_example():
         "author_name": "O'Reilly",
         "author_url": "https://www.youtube.com/user/OreillyMedia",
         "description": "From the 2015 Velocity Conference in New York: I\u2019m going to talk about cognitive bias in operations land. I will go through two examples. The first example i...",
+        "full_description": "From the 2015 Velocity Conference in New York: I\u2019m going to talk about cognitive bias in operations land. I will go through two examples.The first example is how cognitive biases can help us miss the next great thing. In this case, I will show how we could have almost missed the Docker revolution. I\u2019ll use this example to draw parallels and build up a transition to my second point.The second example is the meat of the talk. In this example I\u2019ll reflect on how blindly rejecting ideas from others unlike yourself is the biggest diversity/integration issue in tech and society.The talk will end with bold assertions about why we are in the tech industry. I will fall short of proposing a solution, but will leave with tech\u2019s problems are society\u2019s problems, and we have to think bigger in our search for solutions.About Bryan Liles (DigitalOcean):Bryan Liles works on strategic initiatives for DigitalOcean. In layman\u2019s terms, this means he writes OSS for DigitalOcean and others. He helps communities move their software to the public cloud, and gets to speak at conferences on topics ranging from Machine Learning to how build the next generation of developers. When not thinking about code, Bryan races cars in straight lines and around turns and builds robots and devicesWatch more from Velocity NYC 2015: https://goo.gl/PZAqiYVisit the Velocity website: http://velocityconf.com/Don't miss an upload! Subscribe! http://goo.gl/szEauhStay Connected to O'Reilly Media by Email - http://goo.gl/YZSWbOFollow O'Reilly Media:http://plus.google.com/+oreillymediahttps://www.facebook.com/OReillyhttps://twitter.com/OReillyMedia",
         "images": [
             {
                 "src": "https://i.ytimg.com/vi/SQ5wYZqHQGo/hqdefault.jpg",

--- a/beavy_modules/url_extractor/lib/fetching_test.py
+++ b/beavy_modules/url_extractor/lib/fetching_test.py
@@ -15,6 +15,15 @@ class StartsWith:
     def __eq__(self, other):
         return other.startswith(self.str)
 
+class Present:
+    def __init__(self, type_=None):
+        self._type = type_
+    def __eq__(self, other):
+        if self._type:
+            return isinstance(other, self._type)
+        return other is not None
+
+
 @pytest.mark.slow
 @pytest.mark.external
 def test_blogger_example():
@@ -521,7 +530,7 @@ def test_youtube_example():
             "Operating System (Software Genre)",
             "cognitive bias"
         ],
-        "locale": "de_DE",
+        "locale": Present(str), # Locale depends on origin of request ...
         "oembed": {
             "author_name": "O'Reilly",
             "author_url": "https://www.youtube.com/user/OreillyMedia",

--- a/beavy_modules/url_extractor/requirements.txt
+++ b/beavy_modules/url_extractor/requirements.txt
@@ -1,5 +1,5 @@
 lassie==0.6.2
-pyoembed==0.1.1
+pyembed==1.3.0
 requests==2.8.1
 six==1.10.0
 beautifulsoup4==4.4.1

--- a/beavy_modules/url_extractor/requirements.txt
+++ b/beavy_modules/url_extractor/requirements.txt
@@ -1,0 +1,6 @@
+lassie==0.6.2
+pyoembed==0.1.1
+requests==2.8.1
+six==1.10.0
+beautifulsoup4==4.4.1
+html5lib==1.0b3

--- a/beavy_modules/url_extractor/requirements.txt
+++ b/beavy_modules/url_extractor/requirements.txt
@@ -1,5 +1,4 @@
 lassie==0.6.2
-pyembed==1.3.0
 requests==2.8.1
 six==1.10.0
 beautifulsoup4==4.4.1

--- a/beavy_modules/url_extractor/views.py
+++ b/beavy_modules/url_extractor/views.py
@@ -2,7 +2,7 @@ from beavy.common.rate_limits import rate_limit
 from beavy.app import cache
 from beavy.utils import api_only
 
-from .lib import extract_oembed, extract_info
+from .lib import extract_info
 from .blueprint import blueprint
 
 
@@ -14,9 +14,4 @@ from flask import request
 @rate_limit("1/second")
 @api_only
 def extract():
-    url = request.args["url"]
-    result = {"url": url,
-              "info": extract_info(url)}
-    if request.args.get("oembed", False):
-        result["oembed"] = extract_oembed(url)
-    return result
+    return extract_info(request.args["url"])

--- a/beavy_modules/url_extractor/views.py
+++ b/beavy_modules/url_extractor/views.py
@@ -1,0 +1,14 @@
+from beavy.common.rate_limits import rate_limit
+from beavy.app import cache
+from beavy.utils import api_only
+from .blueprint import blueprint
+from flask import request
+
+@blueprint.route('extract')
+@cache.memoize(15 * 60) # keep in cache for 15min
+# @login_required
+@rate_limit("1/second")
+@api_only
+def extract():
+    url = request.args["url"]
+    return {"url": url}

--- a/beavy_modules/url_extractor/views.py
+++ b/beavy_modules/url_extractor/views.py
@@ -1,7 +1,11 @@
 from beavy.common.rate_limits import rate_limit
 from beavy.app import cache
 from beavy.utils import api_only
+
+from .lib import extract_oembed, extract_info
 from .blueprint import blueprint
+
+
 from flask import request
 
 @blueprint.route('extract')
@@ -11,4 +15,8 @@ from flask import request
 @api_only
 def extract():
     url = request.args["url"]
-    return {"url": url}
+    result = {"url": url,
+              "info": extract_info(url)}
+    if request.args.get("oembed", False):
+        result["oembed"] = extract_oembed(url)
+    return result

--- a/manager.py
+++ b/manager.py
@@ -57,8 +57,25 @@ class Behave(Command):
 
         exit(behave_main(sys.argv[2:] + ['--no-capture', "beavy_apps/{}/tests/features".format(frontend)]))
 
-behave = Behave()
-manager.add_command("behave", behave)
+
+manager.add_command("behave", Behave())
+
+class PyTest(Command):
+    def run(self):
+        import pytest
+
+        arguments = ["--cov-config", ".coveragerc", "--cov=beavy", "beavy"]
+
+        for module in app.config.get("MODULES", []):
+            arguments.append("--cov=beavy_modules/{}".format(module))
+            arguments.append("beavy_modules/{}".format(module))
+
+        arguments.append("--cov=beavy_apps/{}".format(app.config["APP"]))
+        arguments.append("beavy_apps/{}".format(app.config["APP"]))
+
+        exit(pytest.main(arguments))
+
+manager.add_command("pytest", PyTest())
 
 if __name__ == '__main__':
     manager.run()


### PR DESCRIPTION
Adds v1 of the external URL information grabber module,
with support for extracting image (og:image, twitter:image, favicons)
videos, and oembed information (for e.g. from Youtube and Flickr).

Currently only accessible through the public API, worker process
will follow in a later PR. This PR also ships with a bunch of integration
tests against various information providers, which are therefore considered
officially supported.

As part of this PR, there have also been improvements done on other parts
of Beavy, in particular:

 - this PR adds Redis-Based-Flask-Cache (in Production)
 - this PR improves the RateLimits feature significantly
 - the `@apionly` decorator now also supports all types as return values
   as the fallback render does
 - when passing `?json=1`, the content is now pretty formatted for human
   consumption
 - `nativeTypes` parameter dropped from fallback renderer