### PR TITLE
Add Vagrant for Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ ghostdriver.log
 .DS_Store
 .coverage
 var/*
+Vagrantfile
+start.sh
+.vagrant

--- a/.infrastructure/vagrant/pg_hba.conf
+++ b/.infrastructure/vagrant/pg_hba.conf
@@ -1,0 +1,97 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTIONS]
+# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# plain TCP/IP socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "gss", "sspi",
+# "ident", "peer", "pam", "ldap", "radius" or "cert".  Note that
+# "password" sends passwords in clear text; "md5" is preferred since
+# it sends encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database superuser can access the database using some other method.
+# Noninteractive access to all databases is required during automatic
+# maintenance (custom daily cronjobs, replication, and similar tasks).
+#
+# Database administrative login by Unix domain socket
+local   all             postgres                                peer
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+#local   replication     postgres                                peer
+#host    replication     postgres        127.0.0.1/32            md5
+#host    replication     postgres        ::1/128                 md5

--- a/.infrastructure/vagrant/start.sh
+++ b/.infrastructure/vagrant/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SESSION="beavy"
+
+tmux -2 new-session -d -s $SESSION
+tmux new-window -t $SESSION:1 -n
+tmux split-window -v
+tmux select-pane -t 1
+tmux split-window -h
+tmux send-keys "python install.py && python manager.py db upgrade heads && flask --app=main --debug run"  C-m
+tmux select-pane -t 1
+tmux send-keys "npm install && npm run hot-dev-server" C-m
+tmux select-pane -t 0
+tmux -2 attach-session -t $SESSION

--- a/.infrastructure/vagrant/start.sh
+++ b/.infrastructure/vagrant/start.sh
@@ -9,6 +9,6 @@ tmux select-pane -t 1
 tmux split-window -h
 tmux send-keys "python install.py && python manager.py db upgrade heads && flask --app=main --debug run"  C-m
 tmux select-pane -t 1
-tmux send-keys "npm install && npm run hot-dev-server" C-m
+tmux send-keys "npm install && npm run vagrant" C-m
 tmux select-pane -t 0
 tmux -2 attach-session -t $SESSION

--- a/.infrastructure/vagrant/zshrc
+++ b/.infrastructure/vagrant/zshrc
@@ -1,0 +1,40 @@
+# Set up the prompt
+
+autoload -Uz promptinit
+promptinit
+prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _expand _complete _correct _approximate
+zstyle ':completion:*' format 'Completing %d'
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' menu select=2
+eval "$(dircolors -b)"
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=long
+zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+source /home/vagrant/venv/bin/activate
+cd /vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ after_success:
 cache:
   directories:
     - $HOME/.cache/pip
+    - node_modules
 
 services:
   - redis-server

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,59 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MESSAGE = <<-MESSAGE
+WELCOME to Beavy Development.
+
+Please log in into the develop system with
+
+  vagrant ssh
+
+And start all processes in a tmux session by typing:
+
+  ./start.sh
+
+
+MESSAGE
+
+# The list of packages we want to install
+INSTALL = <<-INSTALL
+sudo apt-get update
+sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev
+INSTALL
+
+# Provising on the system and user level
+SETUP = <<-SETUP
+
+#prepare database
+sudo -u postgres createuser vagrant
+sudo -u postgres createdb -O vagrant beavy-dev
+
+# make sure node is accessible
+sudo ln -s /usr/bin/nodejs /usr/bin/node
+
+# set user bash to zsh
+sudo chsh -s /bin/zsh vagrant
+# create the virualenv for vagrant
+sudo -u vagrant virtualenv -p python3 /home/vagrant/venv
+sudo cp /vagrant/.infrastructure/vagrant/pg_hba.conf /etc/postgresql/9.4/main/pg_hba.conf
+sudo /etc/init.d/postgresql reload
+SETUP
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "debian/jessie64"
+  config.vm.post_up_message = MESSAGE
+
+  config.vm.network "forwarded_port", guest: 2992, host: 2992
+
+  config.vm.synced_folder ".infrastructure/vagrant", "/root/", create: true, group: "www-data", owner: "www-data"
+
+  config.vm.provision "shell", inline: INSTALL
+  config.vm.provision "shell", inline: SETUP
+
+  # add local git and zsh config
+  config.vm.provision "file", source: "~/.gitconfig", destination: "~/.gitconfig"
+  config.vm.provision "file", source: ".infrastructure/vagrant/zshrc", destination: "~/.zshrc"
+
+  config.vm.provision "file", source: ".infrastructure/vagrant/start.sh", destination: "/vagrant/start.sh"
+
+end

--- a/beavy/requirements/base.txt
+++ b/beavy/requirements/base.txt
@@ -74,12 +74,12 @@ pytz==2015.6
 PyYAML==3.11
 redis==2.10.3
 regex==2015.10.22
-requests==2.7.0
+requests==2.8.1
 requests-oauthlib==0.5.0
 rsa==3.2
 simplegeneric==0.8.1
 simplejson==3.8.0
-six==1.9.0
+six==1.10.0
 speaklater==1.3
 SQLAlchemy==1.0.8
 traitlets==4.0.0

--- a/beavy_modules/url_extractor/lib/fetching_test.py
+++ b/beavy_modules/url_extractor/lib/fetching_test.py
@@ -23,6 +23,15 @@ class Present:
             return isinstance(other, self._type)
         return other is not None
 
+class HasItems:
+    def __init__(self, items=[]):
+        self.items = items
+
+    def __eq__(self, other):
+        for it in self.items:
+            if not it in other:
+                return False
+        return True
 
 @pytest.mark.slow
 @pytest.mark.external
@@ -406,13 +415,7 @@ def test_flickr_image_example():
 @pytest.mark.external
 def test_tedCom_example():
     assert extractor.fetch("http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results") == {
-        "alternates": {
-            "application/json+oembed": "http://www.ted.com/services/v1/oembed.json?url=http%3A%2F%2Fwww.ted.com%2Ftalks%2Fandreas_ekstrom_the_moral_bias_behind_your_search_results",
-            "application/xml+oembed": "http://www.ted.com/services/v1/oembed.xml?url=http%3A%2F%2Fwww.ted.com%2Ftalks%2Fandreas_ekstrom_the_moral_bias_behind_your_search_results",
-            "en": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results?language=en",
-            "pt-br": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results?language=pt-br",
-            "x-default": "http://www.ted.com/talks/andreas_ekstrom_the_moral_bias_behind_your_search_results"
-        },
+        "alternates": HasItems(["application/json+oembed","application/xml+oembed", "x-default", "en"]),
         "author_name": "Andreas Ekstr\u00f6m",
         "author_url": "http://www.ted.com/speakers/andreas_ekstrom",
         "description": "Search engines have become our most trusted sources of information and arbiters of truth. But can we ever get an unbiased search result? Swedish author and journalist Andreas Ekstr\u00f6m argues that such a thing is a philosophical impossibility. In this thoughtful talk, he calls on us to strengthen the bonds between technology and the humanities, and he reminds us that behind every algorithm is a set of personal beliefs that no code can ever completely eradicate.",

--- a/beavy_modules/url_extractor/requirements.txt
+++ b/beavy_modules/url_extractor/requirements.txt
@@ -1,5 +1,3 @@
 lassie==0.6.2
-requests==2.8.1
-six==1.10.0
 beautifulsoup4==4.4.1
 html5lib==1.0b3

--- a/install.py
+++ b/install.py
@@ -6,7 +6,10 @@ if __name__ == '__main__':
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
     def install(fn):
-        pip.main(["install", "-r", fn])
+        ERR = pip.main(["install", "-r", fn])
+        if ERR:
+            print ("INSTALL FAILED. CHECK ABOVE")
+            exit(ERR)
 
     try:
         import yaml

--- a/install.py
+++ b/install.py
@@ -4,12 +4,11 @@ if __name__ == '__main__':
     import os
 
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+    FILES = []
 
-    def install(fn):
-        ERR = pip.main(["install", "-r", fn])
-        if ERR:
-            print ("INSTALL FAILED. CHECK ABOVE")
-            exit(ERR)
+    def collect(fn):
+        FILES.append("-r")
+        FILES.append(fn)
 
     try:
         import yaml
@@ -22,17 +21,20 @@ if __name__ == '__main__':
 
 
     if os.environ.get("BEAVY_ENV", None):
-        print("----- Install basic requirements")
-        install(os.path.join(BASE_DIR, "beavy", "requirements", "base.txt"))
+        print("----- Adding basic requirements")
+        collect(os.path.join(BASE_DIR, "beavy", "requirements", "base.txt"))
         if os.environ.get("BEAVY_ENV", None) in ["TEST", "DEV", "DEBUG"]:
-            print("----- Install dev requirements")
-            install(os.path.join(BASE_DIR, "beavy", "requirements", "dev.txt"))
+            print("----- Adding dev requirements")
+            collect(os.path.join(BASE_DIR, "beavy", "requirements", "dev.txt"))
     else:
-        install(os.path.join(BASE_DIR, "beavy", "requirements", "base.txt"))
-        install(os.path.join(BASE_DIR, "beavy", "requirements", "dev.txt"))
+        print("----- Adding dev requirements")
+        collect(os.path.join(BASE_DIR, "beavy", "requirements", "base.txt"))
+        collect(os.path.join(BASE_DIR, "beavy", "requirements", "dev.txt"))
 
     for module in config["MODULES"]:
         filename = os.path.join(BASE_DIR, "beavy_modules", module, "requirements.txt")
         if os.path.exists(filename):
-            print("----- Installing Requirements for {}".format(module))
-            install(filename)
+            print("----- Adding Requirements for {}".format(module))
+            collect(filename)
+
+    exit(pip.main(["install"] + FILES))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "BABEL_JEST_STAGE=0 ./node_modules/jest-cli/bin/jest.js --coverage jsbeavy beavy_modules/ beavy_apps",
     "dev-server": "webpack-dev-server --config .infrastructure/webpack/webpack-dev-server.config.js --progress --colors --port 2992 --inline",
     "hot-dev-server": "webpack-dev-server --config .infrastructure/webpack/webpack-hot-dev-server.config.js --hot --progress --colors --port 2992 --inline",
-    "build": "webpack --config .infrastructure/webpack/webpack-production.config.js --progress --profile --colors"
+    "build": "webpack --config .infrastructure/webpack/webpack-production.config.js --progress --profile --colors",
+    "vagrant": "webpack-dev-server --config .infrastructure/webpack/webpack-hot-dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 2992 --inline"
   },
   "author": "Benjamin Kampmann <ben@create-build-execute.com>",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a Vagrantfile for better and faster development
environments.

The Vagrant is build on top of the debian jessie (latest stable),
installs and configures all dependencies on provising and provides
a nice tmux-based starter script to run both the python processes
(install, migrate and flask run) and npm (install and hot-dev-server).

This PR also fixes #21 along the lines.