### PR TITLE
Turn on polling in webpack watch config

### DIFF
--- a/.infrastructure/webpack/make-webpack-config.js
+++ b/.infrastructure/webpack/make-webpack-config.js
@@ -197,6 +197,7 @@ module.exports = function(options) {
 				color: true,
 				exclude: excludeFromStats
 			}
-		}
+		},
+		watchOptions: options.watchOptions,
 	};
 };

--- a/.infrastructure/webpack/make-webpack-config.js
+++ b/.infrastructure/webpack/make-webpack-config.js
@@ -197,6 +197,9 @@ module.exports = function(options) {
 				color: true,
 				exclude: excludeFromStats
 			}
+		},
+		watchOptions: {
+			poll: 250
 		}
 	};
 };

--- a/.infrastructure/webpack/make-webpack-config.js
+++ b/.infrastructure/webpack/make-webpack-config.js
@@ -197,9 +197,6 @@ module.exports = function(options) {
 				color: true,
 				exclude: excludeFromStats
 			}
-		},
-		watchOptions: {
-			poll: 250
 		}
 	};
 };

--- a/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
+++ b/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
@@ -1,0 +1,13 @@
+var config = require("./make-webpack-config")({
+  devServer: true,
+  hotComponents: true,
+  devtool: "cheap-module-eval-source-map",
+  separateStylesheet: true,
+  // redux_dev_tools: true,
+  debug: true,
+  watchOptions: {
+    poll: 250
+  },
+});
+console.log(JSON.stringify(config, null, 2));
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev-server": "webpack-dev-server --config .infrastructure/webpack/webpack-dev-server.config.js --progress --colors --port 2992 --inline",
     "hot-dev-server": "webpack-dev-server --config .infrastructure/webpack/webpack-hot-dev-server.config.js --hot --progress --colors --port 2992 --inline",
     "build": "webpack --config .infrastructure/webpack/webpack-production.config.js --progress --profile --colors",
-    "vagrant": "webpack-dev-server --config .infrastructure/webpack/webpack-hot-dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 2992 --inline"
+    "vagrant": "webpack-dev-server --config .infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js --hot --progress --colors --host 0.0.0.0 --port 2992 --inline"
   },
   "author": "Benjamin Kampmann <ben@create-build-execute.com>",
   "license": "MIT",


### PR DESCRIPTION
This is a solution for the hot reloading problem in webpack (see #26). It implements the solution proposed [in this blog post](http://andrewhfarmer.com/webpack-watch-in-vagrant-docker/) to use webpack's polling feature to detect file changes.