### PR TITLE
Adds tmux options to start.sh to allow scrolling via mouse

### DIFF
--- a/.infrastructure/vagrant/start.sh
+++ b/.infrastructure/vagrant/start.sh
@@ -3,6 +3,11 @@
 SESSION="beavy"
 
 tmux -2 new-session -d -s $SESSION
+
+tmux set-option -t $SESSION mouse-select-pane on
+tmux set-option -t $SESSION mouse-select-window on
+tmux set-window-option -t $SESSION mode-mouse on
+
 tmux new-window -t $SESSION:1 -n
 tmux split-window -v
 tmux select-pane -t 1


### PR DESCRIPTION
These few options added to the start.sh configure the tmux
session with mouse scrolling enabled. If you have a terminal
set up for scrolling with mouse (like iTerm2 per default)
you can now easily search back the history and select panels
by scrolling and clicking – very useful for debugging ;) .