### PR TITLE
Add xvfb and firefox to Vagrant for headless browser testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ MESSAGE
 # The list of packages we want to install
 INSTALL = <<-INSTALL
 sudo apt-get update
-sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev
+sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev xvfb iceweasel
 INSTALL
 
 # Provising on the system and user level

--- a/docs/Development-App-Setup.adoc
+++ b/docs/Development-App-Setup.adoc
@@ -31,3 +31,12 @@ Once both of them are up and running (`webpack: bundle is now VALID`), redirect 
 ```http://localhost:2992/```
 
 **Congratulations**, you've just started your first beavy social community!
+
+==== [[running-tests-on-vagrant]]Running tests
+
+You can run all tests in the vagrant system now. When running <<./Testing.adoc#running-behave-tests, Behave Tests>> however make sure to run the command inside `xvfb-run` like so:
+
+
+```Bash
+$ xvfb-run python manager.py behave
+```

--- a/docs/Testing.adoc
+++ b/docs/Testing.adoc
@@ -46,7 +46,8 @@ Behave tests can be found for each app in it's subfolder tests/features. The htt
 The only remark here is that only app/module specific steps and environment setups should be defined here locally, most steps, helpers and the environment should imported from the growing library in beavy core, in `beavy/testing`.
 
 
-==== Running behave tests
+
+==== [[running-behave-tests]]Running behave tests
 
 In order to run behave tests, you need to have the server running on `localhost:5000`. Start it with:
 
@@ -56,10 +57,10 @@ $ flask --app=main run
 
 And start the tests via
 ```Bash
-$ python manager.py behave_tests
+$ python manager.py behave
 ```
 
-This will automatically look up the app defined in your config.yaml and run the tests supplied for the app (from `beavy_apps/$app/tests/features`).
+This will automatically look up the app defined in your config.yaml and run the tests supplied for the app (from `beavy_apps/$app/tests/features`). If you are running tests within Vagrant, please make sure to prefix it with `xvfb-run` <<<<./Development-App-Setup.adoc#running-tests-on-vagrant,as described here>>.
 
 
 == Automatic builds with Travis


### PR DESCRIPTION
With the current vagrant setup it wasn't possible anymore to
run our awesome behave-tests in development. These changes
fix that by adding xvfb and firefox (called iceweasel on debian)
to vagrant and adding the documentation on how to run these.

---

.Note: In order to use this, one has to reprovision the vagrant.