### PR TITLE
Show Browser Warnings in Tests

### DIFF
--- a/.infrastructure/webpack/webpack-dev-server.config.js
+++ b/.infrastructure/webpack/webpack-dev-server.config.js
@@ -1,6 +1,6 @@
 module.exports = require("./make-webpack-config")({
 	devServer: true,
-	devtool: "eval",
+	devtool: "#eval",
   separateStylesheet: true,
 	debug: true
 });

--- a/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
+++ b/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
@@ -1,7 +1,7 @@
 var config = require("./make-webpack-config")({
   devServer: true,
   hotComponents: true,
-  devtool: "cheap-module-eval-source-map",
+  devtool: "#cheap-module-eval-source-map",
   separateStylesheet: true,
   // redux_dev_tools: true,
   debug: true,

--- a/.infrastructure/webpack/webpack-hot-dev-server.config.js
+++ b/.infrastructure/webpack/webpack-hot-dev-server.config.js
@@ -1,7 +1,7 @@
 var config = require("./make-webpack-config")({
 	devServer: true,
 	hotComponents: true,
-	devtool: "cheap-module-eval-source-map",
+	devtool: "#cheap-module-eval-source-map",
   separateStylesheet: true,
   // redux_dev_tools: true,
 	debug: true

--- a/.infrastructure/webpack/webpack-production.config.js
+++ b/.infrastructure/webpack/webpack-production.config.js
@@ -5,7 +5,7 @@ module.exports = require("./make-webpack-config")({
 		minimize: true,
 		devtool: null,
 		// devtool: 'eval-source-map'
-		devtool: "source-map"
+		devtool: "#source-map"
 	});
 	// require("./make-webpack-config")({
 	// 	prerender: true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ before_script:
   # firefox, which we need to have xvfb for
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - wget https://chromedriver.storage.googleapis.com/2.12/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip
+  - chmod +x chromedriver
+  - export PATH=$PATH:$PWD
   - psql -c 'create database "beavy-test";' -U postgres
   # now make sure we can build the assets
   - npm run build
@@ -138,6 +142,11 @@ addons:
   postgresql: '9.4'
   code_climate:
     repo_token: 267de20fcb1419ff02cfe22e5009111ffc86347f398762cbb700ad56f8279ca6
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 
 notifications:
   webhooks:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ MESSAGE
 # The list of packages we want to install
 INSTALL = <<-INSTALL
 sudo apt-get update
-sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev xvfb iceweasel
+sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev xvfb  chromedriver chromium-browser
 INSTALL
 
 # Provising on the system and user level
@@ -30,6 +30,8 @@ sudo -u postgres createdb -O vagrant beavy-dev
 
 # make sure node is accessible
 sudo ln -s /usr/bin/nodejs /usr/bin/node
+sudo ln -s /usr/bin/chromium /usr/bin/chrome
+sudo ln -s /usr/lib/chromium/chromedriver /usr/bin/chromedriver
 
 # set user bash to zsh
 sudo chsh -s /bin/zsh vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ MESSAGE
 # The list of packages we want to install
 INSTALL = <<-INSTALL
 sudo apt-get update
-sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev
+sudo apt-get install -y  postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev xvfb iceweasel
 INSTALL
 
 # Provising on the system and user level

--- a/beavy/testing/environment.py
+++ b/beavy/testing/environment.py
@@ -3,10 +3,15 @@ from behaving import environment as benv
 from splinter.browser import Browser
 from beavy.app import app
 from .database import ensure_personas, mixer
+from pprint import pprint
 
 import os
+import logging
+
+log = logging.Logger(__name__)
 
 BEHAVE_DEBUG_ON_ERROR = not os.getenv("CI", False)
+BEHAVE_ERROR_ON_BROWSER_WARNINGS = False # os.getenv("BEHAVE_ERROR_ON_BROWSER_WARNINGS", not BEHAVE_DEBUG_ON_ERROR)
 
 def before_all(context):
 
@@ -50,8 +55,22 @@ def before_scenario(context, scenario):
     benv.before_scenario(context, scenario)
     context.personas = ensure_personas()
 
+
 def after_scenario(context, scenario):
+
+    if getattr(context, "browser", None):
+        has_warnings = False
+        for entry in context.browser.driver.get_log('browser'):
+            if entry["level"] in ["WARNING", "ERROR"]:
+                has_warnings = True
+                log.warning("Browser {level}: {timestamp}: {message}".format(**entry))
+
+        if BEHAVE_ERROR_ON_BROWSER_WARNINGS and has_warnings:
+            print("Exciting – Browser Warnings/Errors!")
+            exit(1)
+
     benv.after_scenario(context, scenario)
+
 
 def after_step(context, step):
     if BEHAVE_DEBUG_ON_ERROR and step.status == "failed":
@@ -63,7 +82,6 @@ def after_step(context, step):
             import pdb
 
         if getattr(context, "browser", None):
-            from pprint import pprint
             pprint(context.browser.driver.get_log('browser')[-10:])
             print("Current Screen: {}".format(context.browser.screenshot()))
 

--- a/beavy/testing/environment.py
+++ b/beavy/testing/environment.py
@@ -25,7 +25,7 @@ def before_all(context):
     # When we're running with PhantomJS we need to specify the window size.
     # This is a workaround for an issue where PhantomJS cannot find elements
     # by text - see: https://github.com/angular/protractor/issues/585
-    context.default_browser = os.getenv("BEHAVE_DEFAULT_BROWSER", 'firefox')
+    context.default_browser = os.getenv("BEHAVE_DEFAULT_BROWSER", 'chrome')
 
     context.default_browser_size = (1280, 1024)
     context.base_url = os.getenv("BEHAVE_BASE_URL",  "http://localhost:{}".format(app.config.get("DEBUG", False) and "2992" or "5000"))

--- a/beavy/testing/environment.py
+++ b/beavy/testing/environment.py
@@ -13,7 +13,7 @@ import os
 log = logging.Logger(__name__)
 
 BEHAVE_DEBUG_ON_ERROR = not os.getenv("CI", False)
-BEHAVE_ERROR_ON_BROWSER_WARNINGS = False # os.getenv("BEHAVE_ERROR_ON_BROWSER_WARNINGS", not BEHAVE_DEBUG_ON_ERROR)
+BEHAVE_ERROR_ON_BROWSER_WARNINGS = os.getenv("BEHAVE_ERROR_ON_BROWSER_WARNINGS", not BEHAVE_DEBUG_ON_ERROR)
 
 def before_all(context):
 

--- a/docs/Development-App-Setup.adoc
+++ b/docs/Development-App-Setup.adoc
@@ -31,3 +31,12 @@ Once both of them are up and running (`webpack: bundle is now VALID`), redirect 
 ```http://localhost:2992/```
 
 **Congratulations**, you've just started your first beavy social community!
+
+==== [[running-tests-on-vagrant]]Running tests
+
+You can run all tests in the vagrant system now. When running <<./Testing.adoc#running-behave-tests, Behave Tests>> however make sure to run the command inside `xvfb-run` like so:
+
+
+```Bash
+$ xvfb-run python manager.py behave
+```

--- a/docs/Testing.adoc
+++ b/docs/Testing.adoc
@@ -46,7 +46,8 @@ Behave tests can be found for each app in it's subfolder tests/features. The htt
 The only remark here is that only app/module specific steps and environment setups should be defined here locally, most steps, helpers and the environment should imported from the growing library in beavy core, in `beavy/testing`.
 
 
-==== Running behave tests
+
+==== [[running-behave-tests]]Running behave tests
 
 In order to run behave tests, you need to have the server running on `localhost:5000`. Start it with:
 
@@ -56,10 +57,10 @@ $ flask --app=main run
 
 And start the tests via
 ```Bash
-$ python manager.py behave_tests
+$ python manager.py behave
 ```
 
-This will automatically look up the app defined in your config.yaml and run the tests supplied for the app (from `beavy_apps/$app/tests/features`).
+This will automatically look up the app defined in your config.yaml and run the tests supplied for the app (from `beavy_apps/$app/tests/features`). If you are running tests within Vagrant, please make sure to prefix it with `xvfb-run` <<<<./Development-App-Setup.adoc#running-tests-on-vagrant,as described here>>.
 
 
 == Automatic builds with Travis


### PR DESCRIPTION
Fixes the #-pragma-style source maps issue and shows
the browser logs when running behave tests.

Unfortunately this doesn't yet display `console.log`-
browser errors. Also the reason why it is currently
not error-ing for CI.