### PR TITLE
Fix Vagrant up permission issue

### DIFF
--- a/.infrastructure/vagrant/zshrc
+++ b/.infrastructure/vagrant/zshrc
@@ -36,5 +36,6 @@ zstyle ':completion:*' verbose true
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
+source /home/vagrant/.nvm/nvm.sh
 source /home/vagrant/venv/bin/activate
 cd /vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ sudo ln -s /usr/lib/chromium/chromedriver /usr/bin/chromedriver
 # install latest node
 git clone git://github.com/creationix/nvm.git ~/.nvm
 . ~/.nvm/nvm.sh
-echo "\n. ~/.nvm/nvm.sh" >> .zshrc
+
 nvm install stable
 nvm alias default stable
 


### PR DESCRIPTION
We accidentially created the zshrc file in the home directory during
the installation process in order to make sure nvm is in our environment.
Thus creating the /Users/ben/.zshrc file before vagrant intended to
copy it over, cause vagrant to refuse to copy over when we ask
it to do that later in the provision process.

This fix moves the environment setup from the installation to
the actual zshrc, where it belonged in the first