### PR TITLE
Fix Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,11 @@ SETUP = <<-SETUP
 sudo -u postgres createuser vagrant
 sudo -u postgres createdb -O vagrant beavy-dev
 
-# make sure node is accessible
+# fix postgres config
+sudo cp /vagrant/.infrastructure/vagrant/pg_hba.conf /etc/postgresql/9.4/main/pg_hba.conf
+sudo /etc/init.d/postgresql reload
+
+# make sure chrome & chromedriver are accessible
 sudo ln -s /usr/bin/chromium /usr/bin/chrome
 sudo ln -s /usr/lib/chromium/chromedriver /usr/bin/chromedriver
 
@@ -66,10 +70,10 @@ sudo npm install -g npm
 
 # set user bash to zsh
 sudo chsh -s /bin/zsh vagrant
+
 # create the virualenv for vagrant
 sudo -u vagrant virtualenv -p python3 /home/vagrant/venv
-sudo cp /vagrant/.infrastructure/vagrant/pg_hba.conf /etc/postgresql/9.4/main/pg_hba.conf
-sudo /etc/init.d/postgresql reload
+
 SETUP
 
 Vagrant.configure(2) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,10 +53,11 @@ sudo -u postgres createdb -O vagrant beavy-dev
 sudo ln -s /usr/bin/chromium /usr/bin/chrome
 sudo ln -s /usr/lib/chromium/chromedriver /usr/bin/chromedriver
 
-# install latest node
-git clone git://github.com/creationix/nvm.git ~/.nvm
-. ~/.nvm/nvm.sh
+# install latest nvm to vagrant
+git clone git://github.com/creationix/nvm.git /home/vagrant/.nvm
+. /home/vagrant/.nvm/nvm.sh
 
+# install latest stable node
 nvm install stable
 nvm alias default stable
 

--- a/docs/Development-Vagrant.adoc
+++ b/docs/Development-Vagrant.adoc
@@ -16,3 +16,16 @@ When run for the first time, this might take a while as vagrant
 has to download the latest version of the virtual box image. Once
 this is done and everything has been set up, you should see a big
 green message welcoming you and asking you to run `start.sh`. **Before you link:Development-Running.adoc[can do that], make sure you properly link:Development-App-Setup.adoc[set up your own app]!**
+
+
+== Troubleshooting
+
+=== Hangs when installing vbGuest
+
+If your `vagrant up --provision` hangs at
+```
+Copy iso file /Applications/VirtualBox.app/Contents/MacOS/VBoxGuestAdditions.iso into the box /tmp/VBoxGuestAdditions.iso
+```
+
+This is due to the `vbguest` plugin – which interferes with the jessie64 image provided. Please kill the process (`CTRL`+`C`, `pkill vagrant`), stop the system (`vagrant halt -f`), **uninstall vbguest** (`vagrant plugin uninstall vagrant-vbguest`)** and restart provisioning. You might encounter an error message at the beginning warning you that the guest-tools aren't up to date,
+but you can ignore that!


### PR DESCRIPTION
Turns out nvm was installed for root not for the vagrant user.
This PR fixes that, reorders the setup install for clarity and
adds some troubleshooting to the vagrant docs to help people,
who might be stuck because of the vbguest-plugin.