### PR TITLE
Improved Error Tracking for Behave on Travis

### DIFF
--- a/beavy/testing/environment.py
+++ b/beavy/testing/environment.py
@@ -51,7 +51,7 @@ def after_scenario(context, scenario):
         has_warnings = False
         for entry in context.browser.driver.get_log('browser'):
 
-            if entry["level"] not in ["WARNING", "ERROR"]:
+            if entry["level"] not in ["WARNING", "ERROR", "SEVERE"]:
                 continue
 
             try:

--- a/beavy/testing/environment.py
+++ b/beavy/testing/environment.py
@@ -81,16 +81,17 @@ def after_scenario(context, scenario):
 
 
 def after_step(context, step):
-    if BEHAVE_DEBUG_ON_ERROR and step.status == "failed":
-        # -- ENTER DEBUGGER: Zoom in on failure location.
-        # NOTE: Use IPython debugger, same for pdb (basic python debugger).
-        try:
-            import ipdb as pdb
-        except ImportError:
-            import pdb
-
+    if step.status == "failed":
         if getattr(context, "browser", None):
             pprint(context.browser.driver.get_log('browser')[-10:])
             print("Current Screen: {}".format(context.browser.screenshot()))
 
-        pdb.post_mortem(step.exc_traceback)
+        if BEHAVE_DEBUG_ON_ERROR:
+            # -- ENTER DEBUGGER: Zoom in on failure location.
+            # NOTE: Use IPython debugger, same for pdb (basic python debugger).
+            try:
+                import ipdb as pdb
+            except ImportError:
+                import pdb
+
+            pdb.post_mortem(step.exc_traceback)


### PR DESCRIPTION
Travis does currently give very little context if
a behave test fails. This change shows browser logs
on all failing steps (not only in the debugging environment)
and increases the watcher to also fail on "SEVERE"
browser warnings.

(The latter will probably make this PR fail right now
as we don't have a favicon.ico ...)