### PR TITLE
Add dokku setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Vagrantfile
 .vagrant
 npm-debug.log
 .transifexrc
+.infrastructure/travis/id_rsa

--- a/.infrastructure/docker-base.yml
+++ b/.infrastructure/docker-base.yml
@@ -3,6 +3,5 @@ _app:
   build: ..
   volumes:
     - ../var/uploads:/APP/uploads
-    - ../var/assets:/APP/assets
   environment:
     BEAVY_ENV: "PRODUCTION"

--- a/.infrastructure/docker/Procfile
+++ b/.infrastructure/docker/Procfile
@@ -1,0 +1,2 @@
+web: gunicorn main:app -w 4 -b 5000
+worker: celery -A beavy.app.celery worker -l info

--- a/.infrastructure/docker/Procfile
+++ b/.infrastructure/docker/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn main:app -w 4 -b 5000
+web: gunicorn main:app -w 4 -b :5000
 worker: celery -A beavy.app.celery worker -l info

--- a/.infrastructure/docker/run.sh
+++ b/.infrastructure/docker/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+echo "starting $1"
+# we do the weirdest hack of them all. if the "PORT" variable is exposed
+# we _are_ the web process. so start web and otherwise, start the worker.
+# see  https://github.com/dokku/dokku/blob/v0.4.14/dokku#L143-L159
+cd /app
+if [[ -n "$PORT" ]]; then
+  echo "Running migrations"
+  python manager.py db upgrade heads
+  echo "Starting Web Service"
+  start web
+else
+  echo "Starting Worker Service"
+  start worker
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 env:
   global:
     # ✨ UNCOMMENT AND CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
-    # - DEPLOY_COMMAND="git deploy dokku@SERVER:APP HEAD:master"
+    # - DEPLOY_COMMAND="git push -f dokku@SERVER:APP HEAD:master"
     # ✨ CHANGE THE FOLLOWING TO SLUG OF YOUR REPO AND BRANCH
     #    TO TRIGGER DEPLOY
     - DEPLOY_SLUG=beavyHQ/beavy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ python:
 
 env:
   global:
-    # ✨ CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
-    - DEPLOY_SERVER="root@46.101.137.120"
-    - DEPLOY_PATH="~/beavy-apps"
+    # ✨ UNCOMMENT AND CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
+    # - DEPLOY_COMMAND="git deploy dokku@SERVER:APP HEAD:master"
     # ✨ CHANGE THE FOLLOWING TO SLUG OF YOUR REPO AND BRANCH
     #    TO TRIGGER DEPLOY
     - DEPLOY_SLUG=beavyHQ/beavy
@@ -96,7 +95,7 @@ after_success:
     set -e
 
     # start ssh agent
-    export DEPLOY_PATH_FULL="$DEPLOY_PATH/$APP"
+    export DEFAULT_DEPLOY_SERVER="root@46.101.137.120"
     export NEW_TAG="CI_$APP_$TRAVIS_JOB_NUMBER"
 
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&
@@ -112,14 +111,20 @@ after_success:
         git config --global user.name "Travis CI"
         git config --global user.email "travis@beavy.xyz"
 
-        git remote add deploy "$DEPLOY_SERVER:$DEPLOY_PATH_FULL"
-
         git add -f config.yml var/assets/*
         git commit -m"Adding config and assets for deploy"
         git tag $NEW_TAG
 
         # this will trigger the autodeploy if setup properly
-        git push deploy $NEW_TAG
+
+        if [[ -z "$DEPLOY_COMMAND" ]]; then
+          # Without a deploy command, we use our default setup
+          # for beavy itself
+          git remote add deploy "$DEFAULT_DEPLOY_SERVER:~/beavy-apps/$APP"
+          git push deploy $NEW_TAG
+        else
+          eval "$DEPLOY_COMMAND"
+        fi
 
     else
       echo "We are not on the target deploy branch. Aborting."

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,20 @@ MAINTAINER ben@create-build-execute.com
 
 RUN apt-get update && apt-get upgrade -y
 
-RUN groupadd app && useradd --create-home --home-dir /APP -g app app
-
 ENV PYTHONUNBUFFERED 1
-RUN mkdir -p /APP
-WORKDIR /APP
-ADD beavy/ /APP/beavy/
-ADD beavy_modules /APP/beavy_modules/
-ADD beavy_apps /APP/beavy_apps/
-ADD migrations /APP/migrations/
-ADD config.yml /APP/
-ADD *.py /APP/
+ENV BEAVY_ENV PRODUCTION
+RUN mkdir -p /app
+WORKDIR /app
+ADD beavy/ /app/beavy/
+ADD beavy_modules /app/beavy_modules/
+ADD beavy_apps /app/beavy_apps/
+ADD migrations /app/migrations/
+ADD var/assets/ /app/assets/
+ADD config.yml /app/
+ADD .infrastructure/docker/Procfile /app
+ADD .infrastructure/docker/run.sh /app/run.sh
+
+ADD *.py /app/
 
 RUN pip install pyyaml
 RUN python install.py
-
-USER app

--- a/beavy/app.py
+++ b/beavy/app.py
@@ -44,6 +44,18 @@ def make_env(app):
     with open(os.path.join(os.getcwd(), 'config.yml'), "r") as r:
         deepmerge(app.config, yaml.load(r))
 
+    # allow for environment variables to update items
+    if os.environ.get("BEAVY_CONFIG_FROM_ENV", False):
+        app.config.update(os.environ)
+
+        if "DATABASE_URL" in os.environ:
+            app.config["SQLALCHEMY_DATABASE_URI"] = os.environ["DATABASE_URL"]
+        if "RABBITMQ_URL" in os.environ:
+            app.config["CELERY_BROKER_URL"] = os.environ["RABBITMQ_URL"]
+        if "REDIS_URL" in os.environ:
+            app.config["RATELIMIT_STORAGE_URL"] = os.environ["REDIS_URL"]
+            app.config["CACHE_REDIS_URL"] = os.environ["REDIS_URL"]
+
     # update social buttons
     _FLBLPRE = "flask_social_blueprint.providers.{}"
     if "SOCIAL_BLUEPRINT" not in app.config:

--- a/beavy/requirements/base.txt
+++ b/beavy/requirements/base.txt
@@ -1,14 +1,14 @@
 alembic==0.8.2
-amqp==1.4.6
+amqp==1.4.9
 aniso8601==1.0.0
 anyjson==0.3.3
 appnope==0.1.0
 awesome-slugify==1.6.5
 Babel==2.1.1
 bcrypt==2.0.0
-billiard==3.3.0.20
+billiard==3.3.0.23
 blinker==1.4
-celery==3.1.18
+celery==3.1.23
 cffi==1.2.1
 charlatan==0.4.6
 click==5.1
@@ -43,7 +43,7 @@ google-api-python-client==1.4.2
 httplib2==0.9.2
 itsdangerous==0.24
 Jinja2==2.8
-kombu==3.0.26
+kombu==3.0.34
 limits==1.0.8
 Mako==1.0.2
 MarkupSafe==0.23
@@ -72,7 +72,7 @@ python-dateutil==2.4.2
 python-editor==0.4
 python-mimeparse==0.1.4
 -e git+https://github.com/ligthyear/python-twitter@0b4eee944f21eec4c81145a454fdb90037967ce1#egg=python_twitter-origin_python-3
-pytz==2015.6
+pytz==2015.7
 PyYAML==3.11
 redis==2.10.3
 regex==2015.10.22

--- a/beavy/requirements/production.txt
+++ b/beavy/requirements/production.txt
@@ -1,0 +1,2 @@
+gunicorn==19.4.5
+start==0.2

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -94,43 +94,8 @@ In details this is what they do:
  - `BEAVY_CONFIG_FROM_ENV=1` enabled Environment-variables overwrite of configuration values. This is necessary because dokku exposes connections to the backend services via environment variables we need to configure the service
  - `DOKKU_DOCKERFILE_START_CMD='/app/run.sh'` informs dokku to run a custom script we are shipping in the container, which allows us to start either web or worker processes and scale properly with dokku features
   - `C_FORCE_ROOT=1` informs celerey (our worker system) that is fine to run as root. At the moment, dokku makes somes troubles if we run the service as a different user. But constraint in the container that doesn't matter that much.
+  - SECRET_KEY and SECURITY_PASSWORD_SALT are overwriting our configuration options. Both have a short command in there to generate a random 32 character long alphanumeric key _once_ and becomes the value. This is the safest way to keep your system secure.
 
-== Your first push
-
-Now you can try to push the app for the first time, to see if it builds properly. If you haven't yet created a local `config.yml` for your app, do that and force add it to git (`git add -f config.yml`) – otherwise it will break (with `lstat config.yml: no such file or directory`).
-
-=== Assets
-
-In the build, the system currently assumes the pre-built assets are shipped in the repository. Once we have travis set up, that will happen automatically, but if you want to push from your local repository, the build will fail because it can't find them.
-
-To still be able to push, we recommend you check out a temporary branch, build the assets (for e.g. from within your vagrant), commit and push that. The commands would be as follows
-
-```
-export BEAVY_ENV=PRODUCTION
-git co -b test-deploy
-npm install --all
-npm run build
-git add -f config.yml var/assets/*
-git commit -m"Adding config and assets for deploy"
-```
-
-Then you can push the current HEAD of your git via (this does _not_ push uncommitted changes!):
-
-```
-git push dokku@SERVER:hello-world HEAD:master
-```
-
-
-The first push might take a while because dokku needs to make the first pull of the docker image and other dependencies, and the output will inform you about all the stuff going on. But if it all succeeds it will end with something along the lines of:
-
-```
-=====> Application deployed:
-       http://hello-world.example.com
-```
-
-And you can now find your app running on the mentioned URL.
-
-YAY \o/
 
 == Travis setup
 
@@ -226,3 +191,45 @@ git push
 ```
 
 You are done now!
+
+
+== Troubleshooting
+
+=== Pushing locally
+
+If you have problems deploying, first make sure you can actually push to the dokku server. You can try that locally by creating a test branch, generate the assets (as that is needed first) and push that to dokku as follows:
+
+In the build, the system currently assumes the pre-built assets are shipped in the repository. Once we have travis set up, that will happen automatically, but if you want to push from your local repository, the build will fail because it can't find them.
+
+To still be able to push, we recommend you check out a temporary branch, build the assets (for e.g. from within your vagrant), commit and push that. The commands would be as follows
+
+```
+export BEAVY_ENV=PRODUCTION
+git checkout -b test-deploy
+npm install --all
+npm run build
+git add -f var/assets/*
+git commit -m"Adding assets for deploy"
+```
+
+Then you can push the current HEAD of your git via (this does _not_ push uncommitted changes!):
+
+```
+git push dokku@SERVER:hello-world HEAD:master
+```
+
+
+The first push might take a while because dokku needs to make the first pull of the docker image and other dependencies, and the output will inform you about all the stuff going on. But if it all succeeds it will end with something along the lines of:
+
+```
+=====> Application deployed:
+       http://hello-world.example.com
+```
+
+And you can now find your app running on the mentioned URL.
+
+If this worked all fine, your dokku setup is working just fine and you should investigate the travis setup.
+
+=== Getting help
+
+If you have other troubles, you are welcome to swing by our link:https://gitter.im/beavyHQ/beavy[Gitter Online Chat] and we will try to help you fixing the problems.

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -12,7 +12,6 @@ For any Beavy app we need to install a link:http://dokku.viewdocs.io/dokku/plugi
 dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
 dokku plugin:install https://github.com/dokku/dokku-rabbitmq.git rabbitmq
 dokku plugin:install https://github.com/dokku/dokku-redis.git redis
-dokku plugin:install https://github.com/OzConseil/dokku-deploy-script.git
 ```
 
 == Create and Configure app

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -198,7 +198,7 @@ addons:
 
 In order for travis to be able to push to dokku, it needs access to the ssh keys. Of course _you should never_ commit your SSH keys into any github repo, but link:https://docs.travis-ci.com/user/encrypting-files[travis allows us to easily add them in an encrypted form] only travis can decrypt them with. In order for that to work. remove the `-secure=[...]` key and its value from the `.travis.yml` file.
 
-Now move an `ida_rsa` ssh-private-key-file, which has push-access to the dokku at `.infrastructure/travis/id_rsa` and run the travis encrypt command as follows (if you haven't yet, you might need to install and login with it first – see link:https://docs.travis-ci.com/user/encrypting-files[their docs on how to do that]): `travis encrypt .infrastructure/travis/id_rsa .infrastructure/travis/id_rsa.in`
+Now move an `ida_rsa` ssh-private-key-file, which has push-access to the dokku at `.infrastructure/travis/id_rsa` and run the travis encrypt command as follows (if you haven't yet, you might need to install and login with it first – see link:https://docs.travis-ci.com/user/encrypting-files[their docs on how to do that]): `travis encrypt-file .infrastructure/travis/id_rsa .infrastructure/travis/id_rsa.in`
 
 This encrypts the file and tells you about a command that you should add into your `.travis.yml` file, starting with `openssl aes-256...`. Copy that string and search for `openssl` in the current `.travis.yml`, should find a line which is again marked with a ✨ on top. Replace that command by pasting the one from the command line over it. Save the travis file.
 

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -112,7 +112,7 @@ Just open the file in the editor of your choice and search for the `✨` (sparkl
 env:
   global:
     # ✨ UNCOMMENT AND CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
-    # - DEPLOY_COMMAND="git deploy dokku@SERVER:APP HEAD:master"
+    # - DEPLOY_COMMAND="git push -f dokku@SERVER:APP HEAD:master"
     # ✨ CHANGE THE FOLLOWING TO SLUG OF YOUR REPO AND BRANCH
     #    TO TRIGGER DEPLOY
     - DEPLOY_SLUG=beavyHQ/beavy
@@ -134,7 +134,7 @@ Do as the comments say, uncommment the `DEPLOY_COMMAND` and fill in server-ip an
 env:
   global:
     # ✨ UNCOMMENT AND CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
-    - DEPLOY_COMMAND="git deploy dokku@127.0.0.1:hello-world HEAD:master"
+    - DEPLOY_COMMAND="git push -f dokku@127.0.0.1:hello-world HEAD:master"
     # ✨ CHANGE THE FOLLOWING TO SLUG OF YOUR REPO AND BRANCH
     #    TO TRIGGER DEPLOY
     - DEPLOY_SLUG=EXAMPLE/hello-wolrd

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -168,6 +168,32 @@ env:
     - APP=hello_world
 ```
 
+*Add Dokku to known hosts*
+
+Search for the ✨ again and you should find one in the `addons->ssh_known_hosts` section, looking as follows:
+
+```yaml
+addons:
+  ssh_known_hosts:
+    - github.com
+    - 46.101.137.120
+    # ✨ ADD YOUR DEPLOYMENT SERVERNAME/IP HERE:
+    # - myserver.example.org
+  postgresql: '9.4'
+```
+
+Here, add the dokku server, so that travis will be able to connect and push to it through a ssh-tunneled git command. *Use the same name as you have for the push command before*, so if that is a domain, use that domain, if it was an IP use the ip. In our example it was the (localhost) IP `127.0.0.1`, so we will add that here. It would then look like the following:
+
+```yaml
+addons:
+  ssh_known_hosts:
+    - github.com
+    - 46.101.137.120
+    # ✨ ADD YOUR DEPLOYMENT SERVERNAME/IP HERE:
+    - 127.0.0.1
+  postgresql: '9.4'
+```
+
 *Update ssh keys*
 
 In order for travis to be able to push to dokku, it needs access to the ssh keys. Of course _you should never_ commit your SSH keys into any github repo, but link:https://docs.travis-ci.com/user/encrypting-files[travis allows us to easily add them in an encrypted form] only travis can decrypt them with. In order for that to work. remove the `-secure=[...]` key and its value from the `.travis.yml` file.

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -58,19 +58,57 @@ dokku docker-options:add hello-world deploy,run "-v /home/dokku/hello-world/uplo
 dokku docker-options:add hello-world deploy,run "-v /home/dokku/hello-world/backups:/APP/backups"
 ```
 
-=== Set Enviroment Configuration
+=== Set Environment Configuration
 
-Running beavy on the server means we need to expose the proper enviroment variables
+Running beavy on the server means we need to expose the proper environment variables
 
 `dokku config:set hello-world DOKKU_DOCKERFILE_PORT=5000 BEAVY_ENV=PRODUCTION BEAVY_CONFIG_FROM_ENV=1 DOKKU_DOCKERFILE_START_CMD='/app/run.sh' C_FORCE_ROOT=1`
 
 This informs dokku that we will be hosting the project on port 5000, tells beavy to run in the production mode and understand the environment variables as configuration option. This way it will automatically detect the services we linked perviously. In this mode, you can set any (first-level) configuration option of beavy via `dokku config:set`, too.
 
+In details this is what they do:
+
+ - `DOKKU_DOCKERFILE_PORT=5000` tells dokku that we will be serving on port `5000`.
+ - `BEAVY_ENV=PRODUCTION` sets beavy into production mode.
+ - `BEAVY_CONFIG_FROM_ENV=1` enabled Environment-variables overwrite of configuration values. This is necessary because dokku exposes connections to the backend services via environment variables we need to configure the service
+ - `DOKKU_DOCKERFILE_START_CMD='/app/run.sh'` informs dokku to run a custom script we are shipping in the container, which allows us to start either web or worker processes and scale properly with dokku features
+  - `C_FORCE_ROOT=1` informs celerey (our worker system) that is fine to run as root. At the moment, dokku makes somes troubles if we run the service as a different user. But constraint in the container that doesn't matter that much.
+
 == Your first push
 
-Now you can try to push the app for the first time, to see if it builds properly. If you haven't yet created a local `config.yml` for your app, do that and force add it to git (`git add -f config.yml`) – otherwise it will break (with `lstat config.yml: no such file or directory`). In your git do `git push dokku@SERVER:hello-world HEAD:master` (dokku only deploys `master` branches). The first push might take a while as it is building the docker container for the first time.
+Now you can try to push the app for the first time, to see if it builds properly. If you haven't yet created a local `config.yml` for your app, do that and force add it to git (`git add -f config.yml`) – otherwise it will break (with `lstat config.yml: no such file or directory`).
 
-After a lot of output about installing, it should end with something like:
+=== Assets
+
+In the build, the system currently assumes the pre-built assets are shipped in the repository. Once we have travis set up, that will happen automatically, but if you want to push from your local repository, the build will fail because it can't find them.
+
+To still be able to push, we recommend you check out a temporary branch, build the assets (for e.g. from within your vagrant), commit and push that. The commands would be as follows
+
+```
+export BEAVY_ENV=PRODUCTION
+git co -b test-deploy
+npm install --all
+npm run build
+git add -f config.yml var/assets/*
+git commit -m"Adding config and assets for deploy"
 ```
 
+Then you can push the current HEAD of your git via (this does _not_ push uncommitted changes!):
+
 ```
+git push dokku@SERVER:hello-world HEAD:master
+```
+
+
+The first push might take a while because dokku needs to make the first pull of the docker image and other dependencies, and the output will inform you about all the stuff going on. But if it all succeeds it will end with something along the lines of:
+
+```
+=====> Application deployed:
+       http://hello-world.example.com
+```
+
+And you can now find your app running on the mentioned URL.
+
+YAY \o/
+
+== Travis setup

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -1,0 +1,77 @@
+= Deploying with Dokku
+
+_This Guide was written for dokku 0.4.14._
+
+If you haven't yet, start by link:http://dokku.viewdocs.io/dokku/installation/[installing dokku]. If you want to run it on DigitalOcean, they provide a handy link:https://www.digitalocean.com/community/tutorials/how-to-use-the-dokku-one-click-digitalocean-image-to-run-a-node-js-app[one-click-installer for dokku].
+
+== Required Plugins
+
+For any Beavy app we need to install a link:http://dokku.viewdocs.io/dokku/plugins/[few plugins with dokku], mostly to provide external services like Database and Queuing. You need to install the following plugins: Redis, Postgres, RabbitMQ and Pre-Deploy-Services. Run the following commands on your dokku server (as root):
+
+```bash
+dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
+dokku plugin:install https://github.com/dokku/dokku-rabbitmq.git rabbitmq
+dokku plugin:install https://github.com/dokku/dokku-redis.git redis
+dokku plugin:install https://github.com/OzConseil/dokku-deploy-script.git
+```
+
+== Create and Configure app
+
+Start by creating your beavy app. We will use the "hello-world" as an example here for the appname, replace it with your appropriate name.
+
+`dokku apps:create hello-world`
+
+=== Create backends
+
+Next up we need to create the backend services and link them to our new app
+
+For Redis:
+
+```bash
+dokku redis:create hello-world
+dokku redis:link hello-world hello-world
+```
+
+For Postgres:
+
+```bash
+dokku postgres:create hello-world
+dokku postgres:link hello-world hello-world
+```
+
+For RabbitMQ:
+
+```bash
+dokku rabbitmq:create hello-world
+dokku rabbitmq:link hello-world hello-world
+```
+
+To confirm you can type `dokku config hello-world` and should see all the previously mentioned services are linked there.
+
+---
+
+We need to setup some volumes for persistent storage
+
+```bash
+sudo -u dokku mkdir -p /home/dokku/hello-world/uploads
+sudo -u dokku mkdir -p /home/dokku/hello-world/backups
+dokku docker-options:add hello-world deploy,run "-v /home/dokku/hello-world/uploads:/APP/uploads"
+dokku docker-options:add hello-world deploy,run "-v /home/dokku/hello-world/backups:/APP/backups"
+```
+
+=== Set Enviroment Configuration
+
+Running beavy on the server means we need to expose the proper enviroment variables
+
+`dokku config:set hello-world DOKKU_DOCKERFILE_PORT=5000 BEAVY_ENV=PRODUCTION BEAVY_CONFIG_FROM_ENV=1 DOKKU_DOCKERFILE_START_CMD='/app/run.sh' C_FORCE_ROOT=1`
+
+This informs dokku that we will be hosting the project on port 5000, tells beavy to run in the production mode and understand the environment variables as configuration option. This way it will automatically detect the services we linked perviously. In this mode, you can set any (first-level) configuration option of beavy via `dokku config:set`, too.
+
+== Your first push
+
+Now you can try to push the app for the first time, to see if it builds properly. If you haven't yet created a local `config.yml` for your app, do that and force add it to git (`git add -f config.yml`) – otherwise it will break (with `lstat config.yml: no such file or directory`). In your git do `git push dokku@SERVER:hello-world HEAD:master` (dokku only deploys `master` branches). The first push might take a while as it is building the docker container for the first time.
+
+After a lot of output about installing, it should end with something like:
+```
+
+```

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -118,3 +118,70 @@ And you can now find your app running on the mentioned URL.
 YAY \o/
 
 == Travis setup
+
+We use the (for open source free) link:https://travis-ci.org[Travis build service] on github to run continuous testing, integration and deploy and recommend you do the same. We already bring all the things you need to get started. Just head over to travis and activate the repository link:https://travis-ci.org/profile[on your account page].
+
+
+=== Update Travis config keys
+
+The only other thing you need to do is adapt the `.travis.yml` configuration to automatically deploy to your server.
+
+Just open the file in the editor of your choice and search for the `✨` (sparkle) sign, it alerts you about things you need to change. You should find the following section:
+
+```yaml
+env:
+  global:
+    # ✨ UNCOMMENT AND CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
+    # - DEPLOY_COMMAND="git deploy dokku@SERVER:APP HEAD:master"
+    # ✨ CHANGE THE FOLLOWING TO SLUG OF YOUR REPO AND BRANCH
+    #    TO TRIGGER DEPLOY
+    - DEPLOY_SLUG=beavyHQ/beavy
+    - DEPLOY_BRANCH=master
+    # ✨ END OF CHANGES
+    - BEAVY_ENV=TEST
+    - secure: [..redacted..]
+  matrix:
+    # ✨ REPLACE THESE WITH THE APP YOU WANT TO BUILD
+    # RECOMMENDED WAY: comment these and add your own after
+    - APP=minima
+    - APP=hacker_news
+    # - APP=myAwesomeApp
+```
+
+Do as the comments say, uncommment the `DEPLOY_COMMAND` and fill in server-ip and app-name. In our case this would become ` - DEPLOY_COMMAND git deploy dokku@127.0.0.1:hello-world HEAD:master`. Then update the DEPLOY_SLUG and deploy branch. Lastly remove the existing apps and replace it with the app you want to build. In our example this would look like this:
+
+```yaml
+env:
+  global:
+    # ✨ UNCOMMENT AND CHANGE THE FOLLOWING TO THE REMOTE SERVER YOU WANT TO BUILD
+    - DEPLOY_COMMAND="git deploy dokku@127.0.0.1:hello-world HEAD:master"
+    # ✨ CHANGE THE FOLLOWING TO SLUG OF YOUR REPO AND BRANCH
+    #    TO TRIGGER DEPLOY
+    - DEPLOY_SLUG=EXAMPLE/hello-wolrd
+    - DEPLOY_BRANCH=hello-world
+    # ✨ END OF CHANGES
+    - BEAVY_ENV=TEST
+    - secure: [..redacted..]
+  matrix:
+    # ✨ REPLACE THESE WITH THE APP YOU WANT TO BUILD
+    # RECOMMENDED WAY: comment these and add your own after
+    - APP=hello_world
+```
+
+*Update ssh keys*
+
+In order for travis to be able to push to dokku, it needs access to the ssh keys. Of course _you should never_ commit your SSH keys into any github repo, but link:https://docs.travis-ci.com/user/encrypting-files[travis allows us to easily add them in an encrypted form] only travis can decrypt them with. In order for that to work. remove the `-secure=[...]` key and its value from the `.travis.yml` file.
+
+Now move an `ida_rsa` ssh-private-key-file, which has push-access to the dokku at `.infrastructure/travis/id_rsa` and run the travis encrypt command as follows (if you haven't yet, you might need to install and login with it first – see link:https://docs.travis-ci.com/user/encrypting-files[their docs on how to do that]): `travis encrypt .infrastructure/travis/id_rsa .infrastructure/travis/id_rsa.in`
+
+This encrypts the file and tells you about a command that you should add into your `.travis.yml` file, starting with `openssl aes-256...`. Copy that string and search for `openssl` in the current `.travis.yml`, should find a line which is again marked with a ✨ on top. Replace that command by pasting the one from the command line over it. Save the travis file.
+
+Now add `.travis.yml` and `.infrastructure/travis/id_rsa.in` - more sure **TO NOT** add the source ssh key – and commit the changes. Now push to the repo and travis should automatically pick it up, run the tests and deploy it on your server!
+
+```
+git add .travis.yml .infrastructure/travis/id_rsa.in
+git ci -m"Adding travis and dokku deploy setup"
+git push
+```
+
+You are done now!

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -4,6 +4,10 @@ _This Guide was written for dokku 0.4.14._
 
 If you haven't yet, start by link:http://dokku.viewdocs.io/dokku/installation/[installing dokku]. If you want to run it on DigitalOcean, they provide a handy link:https://www.digitalocean.com/community/tutorials/how-to-use-the-dokku-one-click-digitalocean-image-to-run-a-node-js-app[one-click-installer for dokku].
 
+> *Digital Ocean Notes*
+> Make sure, however to *disable* IPv6 support when creating the droplet, link:http://dokku.viewdocs.io/dokku/getting-started/install/digitalocean/[as there are known issues with that for dokku].
+> If you are using the pre-built droplet, *make sure* to open a browser with the target IP (or domain) and finish the configuration once the droplet is up (you normally can just leave it as is and click `Finish Setup`). Once you are done with that, you can continue.
+
 == Required Plugins
 
 For any Beavy app we need to install a link:http://dokku.viewdocs.io/dokku/plugins/[few plugins with dokku], mostly to provide external services like Database and Queuing. You need to install the following plugins: Redis, Postgres, RabbitMQ and Pre-Deploy-Services. Run the following commands on your dokku server (as root):
@@ -44,6 +48,8 @@ For RabbitMQ:
 dokku rabbitmq:create hello-world
 dokku rabbitmq:link hello-world hello-world
 ```
+
+> Note: It appears the rabbitmq create hangs sometimes and doesn't do anything. Just press `ctrl` + `c` to confirm and it will continue just fine.
 
 To confirm you can type `dokku config hello-world` and should see all the previously mentioned services are linked there.
 

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -202,7 +202,7 @@ Now move an `ida_rsa` ssh-private-key-file, which has push-access to the dokku a
 
 This encrypts the file and tells you about a command that you should add into your `.travis.yml` file, starting with `openssl aes-256...`. Copy that string and search for `openssl` in the current `.travis.yml`, should find a line which is again marked with a ✨ on top. Replace that command by pasting the one from the command line over it. Save the travis file.
 
-Now add `.travis.yml` and `.infrastructure/travis/id_rsa.in` - more sure **TO NOT** add the source ssh key – and commit the changes. Now push to the repo and travis should automatically pick it up, run the tests and deploy it on your server!
+Now add `.travis.yml` and `.infrastructure/travis/id_rsa.in` - make sure **TO NOT** add the source ssh key – and commit the changes. Now push to the repo and travis should automatically pick it up, run the tests and deploy it on your server!
 
 ```
 git add .travis.yml .infrastructure/travis/id_rsa.in

--- a/docs/Deployment-with-dokku.adoc
+++ b/docs/Deployment-with-dokku.adoc
@@ -8,6 +8,18 @@ If you haven't yet, start by link:http://dokku.viewdocs.io/dokku/installation/[i
 > Make sure, however to *disable* IPv6 support when creating the droplet, link:http://dokku.viewdocs.io/dokku/getting-started/install/digitalocean/[as there are known issues with that for dokku].
 > If you are using the pre-built droplet, *make sure* to open a browser with the target IP (or domain) and finish the configuration once the droplet is up (you normally can just leave it as is and click `Finish Setup`). Once you are done with that, you can continue.
 
+== Beavy Configuration
+
+If you haven't yet created a local `config.yml` for your app. The easiest way to do that is by copying the `config.example.yml` file and fill in all the fields as the configuration asks you to. Don't forget to add the secret keys and don't worry about leaking information here, we will replace them on the production system via environment variables.
+
+Once you are done with that make sure that to force-commit it to repository:
+
+```bash
+git add -f config.yml
+git commit -m"Adding App configuration"
+```
+
+
 == Required Plugins
 
 For any Beavy app we need to install a link:http://dokku.viewdocs.io/dokku/plugins/[few plugins with dokku], mostly to provide external services like Database and Queuing. You need to install the following plugins: Redis, Postgres, RabbitMQ and Pre-Deploy-Services. Run the following commands on your dokku server (as root):
@@ -18,7 +30,7 @@ dokku plugin:install https://github.com/dokku/dokku-rabbitmq.git rabbitmq
 dokku plugin:install https://github.com/dokku/dokku-redis.git redis
 ```
 
-== Create and Configure app
+== Create and Configure dokku app
 
 Start by creating your beavy app. We will use the "hello-world" as an example here for the appname, replace it with your appropriate name.
 
@@ -68,7 +80,10 @@ dokku docker-options:add hello-world deploy,run "-v /home/dokku/hello-world/back
 
 Running beavy on the server means we need to expose the proper environment variables
 
-`dokku config:set hello-world DOKKU_DOCKERFILE_PORT=5000 BEAVY_ENV=PRODUCTION BEAVY_CONFIG_FROM_ENV=1 DOKKU_DOCKERFILE_START_CMD='/app/run.sh' C_FORCE_ROOT=1`
+```bash
+dokku config:set hello-world DOKKU_DOCKERFILE_PORT=5000 BEAVY_ENV=PRODUCTION BEAVY_CONFIG_FROM_ENV=1 DOKKU_DOCKERFILE_START_CMD='/app/run.sh' C_FORCE_ROOT=1 SECRET_KEY=`cat /dev/urandom | tr -dc 'a-zA-Z0-9-!@#$%^&*()_+~' | fold -w 32 | head -n 1` SECURITY_PASSWORD_SALT=`cat /dev/urandom | tr -dc 'a-zA-Z0-9-!@#$%^&*()_+~' | fold -w 32 | head -n 1`
+
+```
 
 This informs dokku that we will be hosting the project on port 5000, tells beavy to run in the production mode and understand the environment variables as configuration option. This way it will automatically detect the services we linked perviously. In this mode, you can set any (first-level) configuration option of beavy via `dokku config:set`, too.
 
@@ -206,7 +221,7 @@ Now add `.travis.yml` and `.infrastructure/travis/id_rsa.in` - make sure **TO NO
 
 ```
 git add .travis.yml .infrastructure/travis/id_rsa.in
-git ci -m"Adding travis and dokku deploy setup"
+git commit -m"Adding travis and dokku deploy setup"
 git push
 ```
 

--- a/install.py
+++ b/install.py
@@ -22,7 +22,11 @@ if __name__ == '__main__':
     if os.environ.get("BEAVY_ENV", None):
         print("----- Adding basic requirements")
         collect(os.path.join(BASE_DIR, "beavy", "requirements", "base.txt"))
-        if os.environ.get("BEAVY_ENV", None) in ["TEST", "DEV", "DEBUG"]:
+    
+        if os.environ.get("BEAVY_ENV", None) == "PRODUCTION":
+            print("----- Adding production requirements")
+            collect(os.path.join(BASE_DIR, "beavy", "requirements", "production.txt"))
+        elif os.environ.get("BEAVY_ENV", None) in ["TEST", "DEV", "DEBUG"]:
             print("----- Adding dev requirements")
             collect(os.path.join(BASE_DIR, "beavy", "requirements", "dev.txt"))
     else:

--- a/install.py
+++ b/install.py
@@ -22,10 +22,11 @@ if __name__ == '__main__':
     if os.environ.get("BEAVY_ENV", None):
         print("----- Adding basic requirements")
         collect(os.path.join(BASE_DIR, "beavy", "requirements", "base.txt"))
-    
+
         if os.environ.get("BEAVY_ENV", None) == "PRODUCTION":
             print("----- Adding production requirements")
-            collect(os.path.join(BASE_DIR, "beavy", "requirements", "production.txt"))
+            collect(os.path.join(BASE_DIR, "beavy", "requirements",
+                                 "production.txt"))
         elif os.environ.get("BEAVY_ENV", None) in ["TEST", "DEV", "DEBUG"]:
             print("----- Adding dev requirements")
             collect(os.path.join(BASE_DIR, "beavy", "requirements", "dev.txt"))

--- a/manager.py
+++ b/manager.py
@@ -35,6 +35,7 @@ ext_migrate._get_config = patched_migrate(ext_migrate._get_config)
 
 from beavy.app import app, manager
 
+
 try:
     from behave.configuration import options as behave_options
     from behave.__main__ import main as behave_main

--- a/manager.py
+++ b/manager.py
@@ -35,9 +35,12 @@ ext_migrate._get_config = patched_migrate(ext_migrate._get_config)
 
 from beavy.app import app, manager
 
-
-from behave.__main__ import main as behave_main
-from behave.configuration import options as behave_options
+try:
+    from behave.configuration import options as behave_options
+    from behave.__main__ import main as behave_main
+    has_behave = True
+except ImportError:
+    has_behave = False
 
 
 def reformat_options(opts):
@@ -74,12 +77,17 @@ class Behave(Command):
         exit(behave_main(sys.argv[2:] + ['--no-capture',
              "beavy_apps/{}/tests/features".format(frontend)]))
 
+if has_behave:
+    manager.add_command("behave", Behave())
 
-manager.add_command("behave", Behave())
+try:
+    import pytest
+    has_pytest = True
+except ImportError:
+    has_pytest = False
 
 
-@manager.command
-def pytest(path=None, no_coverage=False, maxfail=0,
+def pytest(path=None, no_coverage=False, maxfail=0,  # noqa
            debug=False, verbose=False):
     import pytest
 
@@ -111,6 +119,9 @@ def pytest(path=None, no_coverage=False, maxfail=0,
         get_all_beavy_paths(add_path)
 
     exit(pytest.main(arguments))
+
+if has_pytest:
+    manager.command(pytest)
 
 
 class GetPaths(Command):


### PR DESCRIPTION
This PR adds support to have people (automatically) deploy to dokku.

It contains the following changes:

 - simplify .travis.yml to allow easier deploy methods
 - docker setup for dokku based system
 - minor changes on manager, requirements and deploy scripts
 - add possibility to overwrite config var via environment
 - documentation on how to setup beavy on dokku with CI

----

@ezmiller can you confirm this work (especially the last, travis part)?