### PR TITLE
Redo pytests to add more options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
 
 script:
   # we are starting with running all unit tests
-  - python manager.py pytest
+  - python manager.py pytest -v
   # lets run jstests – currently without reporitng
   - npm test
   # starting up test-server

--- a/manager.py
+++ b/manager.py
@@ -78,21 +78,38 @@ class Behave(Command):
 manager.add_command("behave", Behave())
 
 
-class PyTest(Command):
-    def run(self):
-        import pytest
+@manager.command
+def pytest(path=None, no_coverage=False, maxfail=0, debug=False, verbose=False):
+    import pytest
 
-        arguments = ["--cov-config", ".coveragerc", "--cov=beavy", "beavy"]
+    arguments = []
 
-        def add_path(x):
-            arguments.append("--cov={}".format(x))
-            arguments.append(x)
+    def add_path_with_coverage(x):
+        arguments.append("--cov={}".format(x))
+        arguments.append(x)
 
+    if maxfail:
+        arguments.append("--maxfail={}".format(maxfail))
+
+    if verbose:
+        arguments.append("-vv")
+
+    if debug:
+        arguments.append("--pdb")
+
+    if no_coverage:
+        add_path = lambda x: arguments.append(x)
+    else:
+        arguments.extend(["--cov-config", ".coveragerc"])
+        add_path = add_path_with_coverage
+
+    if path:
+        add_path(path)
+    else:
+        add_path("beavy")
         get_all_beavy_paths(add_path)
 
-        exit(pytest.main(arguments))
-
-manager.add_command("pytest", PyTest())
+    exit(pytest.main(arguments))
 
 
 class GetPaths(Command):

--- a/manager.py
+++ b/manager.py
@@ -79,7 +79,8 @@ manager.add_command("behave", Behave())
 
 
 @manager.command
-def pytest(path=None, no_coverage=False, maxfail=0, debug=False, verbose=False):
+def pytest(path=None, no_coverage=False, maxfail=0,
+           debug=False, verbose=False):
     import pytest
 
     arguments = []


### PR DESCRIPTION
- adds flags for verbose, specific paths, maxfails and debug to the pytest command of the manager
 - add flag to turn of coverage (makes local tests faster)
 - make travis run tests in verbose mode