### PR TITLE
Add latest ICU

### DIFF
--- a/.infrastructure/install_icu.sh
+++ b/.infrastructure/install_icu.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+mkdir -p ~/.icu_cache
+mkdir -p ~/lib
+cd ~/.icu_cache
+if [ ! -d "icu4c-57rc-src" ]; then
+    echo "Downloading latest ICU – please wait."
+    wget --quiet http://download.icu-project.org/files/icu4c/57rc/icu4c-57rc-src.tgz
+
+    # checking md5sum!
+    echo "26acb3f79ba926c26bd76094bcf85866 *icu4c-57rc-src.tgz" | md5sum -c -
+
+    tar xf icu4c-57rc-src.tgz
+    mv icu icu4c-57rc-src
+fi
+
+[ "$TRAVIS" == "true" ] && PREFIX="~/lib" || PREFIX="/usr"
+
+echo "Compiling and installing ICU to $PREFIX"
+cd icu4c-57rc-src/source
+./configure prefix=$PREFIX && make && make install
+echo "ICU successfully installed."

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
     # - APP=myAwesomeApp
 
 before_install:
+  # install latest ICU for best localisation support
+  - bash .infrastructure/install_icu.sh
   # if there isn't a config file, pick up the
   # one used for the testing of the app
   - "[ ! -f config.yml ] && cp -f \"beavy_apps/$APP/tests/config.yml\" config.yml || echo \"config file already found\" "
@@ -36,7 +38,7 @@ before_install:
   # install all node dependencies
   - npm install --all
   # install all python dependencies (requires a config.yml!)
-  - python install.py
+  - LD_LIBRARY_PATH=~/lib python install.py
   # install coveralls to send coverage stats there
   - pip install coveralls
 
@@ -136,6 +138,7 @@ after_success:
 cache:
   directories:
     - $HOME/.cache/pip
+    - $HOME/.icu_cache
     - node_modules
 
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,2 @@
-FROM python:3.5
+FROM beavy:beavy-base-image
 MAINTAINER ben@create-build-execute.com
-
-RUN apt-get update && apt-get upgrade -y
-
-ENV PYTHONUNBUFFERED 1
-ENV BEAVY_ENV PRODUCTION
-RUN mkdir -p /app
-WORKDIR /app
-ADD beavy/ /app/beavy/
-ADD beavy_modules /app/beavy_modules/
-ADD beavy_apps /app/beavy_apps/
-ADD migrations /app/migrations/
-ADD var/assets/ /app/assets/
-ADD config.yml /app/
-ADD .infrastructure/docker/Procfile /app
-ADD .infrastructure/docker/run.sh /app/run.sh
-
-ADD *.py /app/
-
-RUN pip install pyyaml
-RUN python install.py

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ MESSAGE
 # The list of packages we want to install
 INSTALL = <<-INSTALL
 sudo apt-get update
-sudo apt-get install -y postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev xvfb chromedriver chromium build-essential libssl-dev curl git-core libicu-dev
+sudo apt-get install -y postgresql-9.4 postgresql-client-9.4 postgresql-server-dev-9.4 redis-server python3 python3-pip python3-virtualenv virtualenv nodejs npm zsh git tmux libffi-dev libncurses5-dev xvfb chromedriver chromium build-essential libssl-dev curl git-core
 
 INSTALL
 
@@ -88,6 +88,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant",  type: 'nfs', mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=1']
 
   config.vm.provision "shell", inline: INSTALL
+  config.vm.provision "shell", path: ".infrastructure/install_icu.sh"
   config.vm.provision "shell", inline: SETUP
 
   # add local git and zsh config


### PR DESCRIPTION


This PR adds a small script to download and installed latest ICU (currently: version 57 from Mar 9th 2016), which is executed on every travis build. This allows us to ensure we have always the latest needed version of it running and ensures we have the same running on all platforms: vagrant, travis and docker!

Secondly, this is part of a bigger refactor, which takes the Dockerfile out into its own repo and makes it available as a pre-compiled image for other to fetch and reuse. That brings the added benefit that deploy should go faster now, as we supply more commons (requirement.txt, ICU and potentially other things) right out of the box rather than letting the user reinstall them every time.
