### PR TITLE
Fix Admin access problem

### DIFF
--- a/beavy/common/admin_model_view.py
+++ b/beavy/common/admin_model_view.py
@@ -38,7 +38,8 @@ class AdminModelView(ModelView):
 
             See commit ``#45a2723`` for details.
         """
-        if 'polymorphic_identity' in self.model.__mapper_args__:
+        if 'polymorphic_identity' in getattr(self.model, "__mapper_args__",
+                                             {}):
             return self.session.query(func.count('*')).select_from(
                 self.model.query.selectable)
 


### PR DESCRIPTION
Some of our models don't have `__mapper_args__` (specifically the
User model) which our query builder assumes to be there. Resulting
in an ugly 500/traceback when trying to access.

This change fixes this by a more error-resistant lookup procedure.