### PR TITLE
Fix Dockerfile URI for new image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM beavy:beavy-base-image
+FROM beavy/beavy-base-image
 MAINTAINER ben@create-build-execute.com


### PR DESCRIPTION
PR #88 introduced a new way of doing the Docker deploy using an already
previously prepared base image. Unfortunately our tests didn't notice
that the URI given in the Dockerfile isn't actually pointing to that
new image. This PR fixes that.