### PR TITLE
Give APP JS precedence

### DIFF
--- a/.infrastructure/webpack/make-webpack-config.js
+++ b/.infrastructure/webpack/make-webpack-config.js
@@ -74,7 +74,7 @@ module.exports = function (options) {
   var externals = [ ]
   var modulesDirectories = ['web_modules', 'node_modules']
   var extensions = ['', '.web.js', '.js', '.jsx']
-  var root = JS_ROOT
+  var root = [path.resolve(ROOT, 'beavy_apps', appConfig.APP, 'frontend'), JS_ROOT]
   var publicPath = options.devServer ? 'http://localhost:2992/assets/' : '/assets/'
   var output = {
     path: path.join(ROOT, 'assets'),


### PR DESCRIPTION
This minor looking edit, changes the load order for JS/JSX modules to give
the configured App precedence over the global beavy code.

This allows an app to overwrite any (global, meaning non prefixed) import
path by placing a file under the same path as the global app does. For e.g.
you can easily provide your own Home-View by simply adding a React
Component under
in your app.