### PR TITLE
Update Redux Devtools

### DIFF
--- a/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
+++ b/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
@@ -4,6 +4,7 @@ var config = require('./make-webpack-config')({
   devtool: '#cheap-module-eval-source-map',
   separateStylesheet: true,
   debug: true,
+  redux_dev_tools: true,
   watchOptions: {
     poll: true
   }

--- a/beavy/jsbeavy/config/devTools.jsx
+++ b/beavy/jsbeavy/config/devTools.jsx
@@ -13,9 +13,8 @@ import SliderMonitor from 'redux-slider-monitor'
 const DevTools = createDevTools(
   <DockMonitor toggleVisibilityKey='ctrl-h'
                changePositionKey='ctrl-q'
-               defaultIsVisible={true}
+               defaultIsVisible
                defaultSize={1.0}
-
                changeMonitorKey='ctrl-m'>
     <LogMonitor />
     <SliderMonitor />

--- a/beavy/jsbeavy/config/devTools.jsx
+++ b/beavy/jsbeavy/config/devTools.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render } from 'react-dom'
+
+// Exported from redux-devtools
+import { createDevTools } from 'redux-devtools'
+
+// Monitors are separate packages, and you can make a custom one
+import LogMonitor from 'redux-devtools-log-monitor'
+import DockMonitor from 'redux-devtools-dock-monitor'
+import SliderMonitor from 'redux-slider-monitor'
+
+// createDevTools takes a monitor and produces a DevTools component
+const DevTools = createDevTools(
+  <DockMonitor toggleVisibilityKey='ctrl-h'
+               changePositionKey='ctrl-q'
+               defaultIsVisible={true}
+               defaultSize={1.0}
+
+               changeMonitorKey='ctrl-m'>
+    <LogMonitor />
+    <SliderMonitor />
+  </DockMonitor>
+)
+
+function showDevTools (store) {
+  const popup = window.open(null, 'Redux DevTools', 'menubar=no,location=no,resizable=no,scrollbars=no,status=no,width=400px')
+  // Reload in case it already exists
+  popup.location.reload()
+
+  setTimeout(() => {
+    popup.document.write('<div id="react-devtools-root"></div>')
+    render(
+      <DevTools store={store} />,
+      popup.document.getElementById('react-devtools-root')
+    )
+  }, 10)
+}
+
+export { DevTools, showDevTools }

--- a/beavy/jsbeavy/config/root.jsx
+++ b/beavy/jsbeavy/config/root.jsx
@@ -62,53 +62,25 @@ export default class Root extends React.Component {
   }
 
   render () {
-    let debugTools = null
-
-    if (__REDUX_DEV_TOOLS__) {
-      const { DevTools, LogMonitor, DebugPanel } = require('redux-devtools/lib/react')
-      if (__DEBUG_NW__) {
-        const win = window.open(
-              null,
-              'redux-devtools', // give it a name so it reuses the same window
-              'menubar=no,location=no,resizable=yes,scrollbars=no,status=no'
-            )
-
-            // reload in case it's reusing the same window with the old content
-        win.location.reload()
-
-            // wait a little bit for it to reload, then render
-        setTimeout(() => {
-          React.render(
-                <DebugPanel top right bottom left >
-                  <DevTools store={this.props.store} monitor={LogMonitor} />
-                </DebugPanel>
-                , win.document.body)
-        }, 10)
-        return
-      } else {
-        debugTools = (
-            <DebugPanel top left bottom key='debugPanel'>
-              <DevTools store={this.props.store} monitor={LogMonitor} />
-            </DebugPanel>
-          )
-      }
+    if (__REDUX_DEV_TOOLS__ ){
+      const { showDevTools } = require('./devTools');
+      showDevTools(this.props.store);
     }
 
     setupViews(this.props.application)
 
     return (
-      <div>
-        {debugTools}
-          <IntlProvider locale='en' messages={ window.PRELOAD.MESSAGES }>
-            <Provider store={this.props.store}>
-              <ReduxRouter>
-                <Route component={this.props.application}>
-                  {this.getRoutes()}
-                </Route>
-              </ReduxRouter>
-            </Provider>
-          </IntlProvider>
-        </div>
+      <IntlProvider locale='en' messages={ window.PRELOAD.MESSAGES }>
+        <Provider store={this.props.store}>
+          <div>
+            <ReduxRouter>
+              <Route component={this.props.application}>
+                {this.getRoutes()}
+              </Route>
+            </ReduxRouter>
+          </div>
+        </Provider>
+      </IntlProvider>
     )
   }
 }

--- a/beavy/jsbeavy/config/root.jsx
+++ b/beavy/jsbeavy/config/root.jsx
@@ -1,4 +1,4 @@
-/*global __DEBUG_NW__, __REDUX_DEV_TOOLS__, __CONFIG__URLS_HOME */
+/*global __REDUX_DEV_TOOLS__, __CONFIG__URLS_HOME */
 import React from 'react'
 import { Provider } from 'react-redux'
 import { Route, Redirect } from 'react-router'
@@ -62,9 +62,9 @@ export default class Root extends React.Component {
   }
 
   render () {
-    if (__REDUX_DEV_TOOLS__ ){
-      const { showDevTools } = require('./devTools');
-      showDevTools(this.props.store);
+    if (__REDUX_DEV_TOOLS__) {
+      const { showDevTools } = require('./devTools')
+      showDevTools(this.props.store)
     }
 
     setupViews(this.props.application)

--- a/beavy/jsbeavy/stores/index.jsx
+++ b/beavy/jsbeavy/stores/index.jsx
@@ -40,12 +40,14 @@ export default function configureStore (initialState) {
   let createStoreWithMiddleware = applyMiddleware.apply(this, middlewares)
 
   if (__REDUX_DEV_TOOLS__) {
-    const { devTools, persistState } = require('redux-devtools')
+    const { DevTools } = require('../config/devTools')
+    const { persistState } = require('redux-devtools')
+
     createStoreWithMiddleware = compose(
         createStoreWithMiddleware,
         reduxReactRouter({ createHistory }),
         // Provides support for DevTools:
-        devTools(),
+        DevTools.instrument(),
         // Lets you write ?debug_session=<name> in address bar to persist debug sessions
         persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
       )

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "react-prosemirror": "^0.1.4",
     "react-intl": "^2.0.0-beta-2",
     "react-proxy-loader": "^0.3.4",
-    "react-redux": "^4.0.0",
+    "react-redux": "^4.4.1",
     "react-router": "^1.0.0-rc1",
-    "redux": "^3.0.4",
+    "redux": "^3.1.1",
     "redux-form": "^3.1.6",
     "redux-router": "^1.0.0-beta5",
     "redux-thunk": "^0.1.0",
@@ -115,8 +115,11 @@
     "jest-webpack": "^0.2.1",
     "po2json": "^0.4.1",
     "react-hot-loader": "^1.3.0",
-    "redux-devtools": "^3.0.0-beta-3",
+    "redux-devtools": "^3.1.1",
+    "redux-devtools-dock-monitor": "^1.1.0",
+    "redux-devtools-log-monitor": "^1.0.5",
     "redux-logger": "^1.0.6",
+    "redux-slider-monitor": "^1.0.2",
     "webpack-dev-server": "^1.14.0"
   }
 }


### PR DESCRIPTION
Update Redux Devtools:

 - Update to latest version of redux dev tools
 - fix our usage of it
 - enable devtools on vagrant to open in a new window