### PR TITLE
Switching to travis to Trusty

### DIFF
--- a/.infrastructure/install_icu.sh
+++ b/.infrastructure/install_icu.sh
@@ -4,20 +4,20 @@ set -e
 mkdir -p "$HOME/.icu_cache"
 mkdir -p "$HOME/lib"
 cd "$HOME/.icu_cache"
-if [ ! -d "icu4c-57rc-src" ]; then
+if [ ! -d "icu4c-57_1-src" ]; then
     echo "Downloading latest ICU – please wait."
-    wget --quiet http://download.icu-project.org/files/icu4c/57rc/icu4c-57rc-src.tgz
+    wget --quiet http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz
 
     # checking md5sum!
-    echo "26acb3f79ba926c26bd76094bcf85866 *icu4c-57rc-src.tgz" | md5sum -c -
+    echo "976734806026a4ef8bdd17937c8898b9 *icu4c-57_1-src.tgz" | md5sum -c -
 
-    tar xf icu4c-57rc-src.tgz
-    mv icu icu4c-57rc-src
+    tar xf icu4c-57_1-src.tgz
+    mv icu icu4c-57_1-src
 fi
 
 [ "$TRAVIS" == "true" ] && PREFIX="$HOME/lib" || PREFIX="/usr"
 
 echo "Compiling and installing ICU to $PREFIX"
-cd icu4c-57rc-src/source
-./configure --prefix=$PREFIX && make && make install
+cd icu4c-57_1-src/source
+./configure --prefix=$PREFIX && make &&  make install
 echo "ICU successfully installed."

--- a/.infrastructure/install_icu.sh
+++ b/.infrastructure/install_icu.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 set -e
-mkdir -p ~/.icu_cache
-mkdir -p ~/lib
-cd ~/.icu_cache
+mkdir -p "$HOME/.icu_cache"
+mkdir -p "$HOME/lib"
+cd "$HOME/.icu_cache"
 if [ ! -d "icu4c-57rc-src" ]; then
     echo "Downloading latest ICU – please wait."
     wget --quiet http://download.icu-project.org/files/icu4c/57rc/icu4c-57rc-src.tgz
@@ -15,9 +15,9 @@ if [ ! -d "icu4c-57rc-src" ]; then
     mv icu icu4c-57rc-src
 fi
 
-[ "$TRAVIS" == "true" ] && PREFIX="~/lib" || PREFIX="/usr"
+[ "$TRAVIS" == "true" ] && PREFIX="$HOME/lib" || PREFIX="/usr"
 
 echo "Compiling and installing ICU to $PREFIX"
 cd icu4c-57rc-src/source
-./configure prefix=$PREFIX && make && make install
+./configure --prefix=$PREFIX && make && make install
 echo "ICU successfully installed."

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - DEPLOY_BRANCH=master
     # ✨ END OF CHANGES
     - BEAVY_ENV=TEST
+    - LD_LIBRARY_PATH=/home/travis/lib
     - secure: 42qbN2sBRUwB8q99XdMJDsr1FelB3fUA8wRjRbH7ZGKRDH6CKHALno/RV2QIzpbJTlwi/6ax5MV3FQTEPN5p726Zj1JiwOun3RW2kRdqCm/xNGyh4B5FxJxyzq0hSIFdJCXihJd1Frm2JltHMkRCadl6VtlmdY9L7N1SRHQoJs0X4wU354LJFpDu2trBZKESUWee73VgdynDwlT6nehwcj42TxyXt9lr3moZUHLIfXvnyMFL7tp1CDMdbAkD4m1hq1UG1jxHQRbHfzTEtem+8oVAi8I3Hrpds4/lnIjP6/LJi8bR3c9rKKykKe1EKZnhYUf/lwD00jdR4g8c1tR3F/kTByFjxGFRfpRUzJXi6dD8Q2JOdu8zVAuIgnZg2Gh+c5z+V3/L27ax1x4sYyiXbi/lQpbE6XSkn4wLWi9Y1TK1kl1N92NkVipLwHz535tcWLwQ9KwzpVUBznGcYw5XQO3sbVcSF4PiEpiET+MjwV5o5MkOfD67FATZo9GlSwKpmSoSsd2JgpjzieRNt+VDyC4liDWco2HA3191DSO2f/q91w3bpwlGRCKP/X78npeIVGCMOzWSnTmPtOLZd3MjC/g/HFb90SG6cjAC1nTkR8RHTAXYBSnUZgr1Gl/8A1I86LSDKhXGoBGHjJTFt0ViAX+Ho9Yn0LCrtrN7SeiuSEs=
   matrix:
     # ✨ REPLACE THESE WITH THE APP YOU WANT TO BUILD
@@ -26,7 +27,6 @@ env:
 before_install:
   # install latest ICU for best localisation support
   - bash .infrastructure/install_icu.sh
-  - export LD_LIBRARY_PATH="/usr/lib:$LD_LIBRARY_PATH"
   # if there isn't a config file, pick up the
   # one used for the testing of the app
   - "[ ! -f config.yml ] && cp -f \"beavy_apps/$APP/tests/config.yml\" config.yml || echo \"config file already found\" "
@@ -39,7 +39,7 @@ before_install:
   # install all node dependencies
   - npm install --all
   # install all python dependencies (requires a config.yml!)
-  - LD_LIBRARY_PATH=~/lib python install.py
+  - python install.py
   # install coveralls to send coverage stats there
   - pip install coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 before_install:
   # install latest ICU for best localisation support
   - bash .infrastructure/install_icu.sh
+  - export LD_LIBRARY_PATH="/usr/lib:$LD_LIBRARY_PATH"
   # if there isn't a config file, pick up the
   # one used for the testing of the app
   - "[ ! -f config.yml ] && cp -f \"beavy_apps/$APP/tests/config.yml\" config.yml || echo \"config file already found\" "

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: false
-
+sudo: required
+dist: trusty
 language: python
 
 python:


### PR DESCRIPTION
We have a continuously broken build because using [chrome-stable on
precise isn't supported any longer](https://github.com/travis-ci/travis-ci/issues/5899). The only
currently known cure it to switch to ubuntu Trusty, which is still in
Travis beta. This is doing that switch and tries to figure out what fails
if we did that..