### PR TITLE
Fixes source mapping for Chrome

### DIFF
--- a/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
+++ b/.infrastructure/webpack/webpack-hot-dev-server-onvagrant.config.js
@@ -1,7 +1,7 @@
 var config = require('./make-webpack-config')({
   devServer: true,
   hotComponents: true,
-  devtool: '#cheap-module-eval-source-map',
+  devtool: '#inline-source-map',
   separateStylesheet: true,
   debug: true,
   redux_dev_tools: true,

--- a/.infrastructure/webpack/webpack-hot-dev-server.config.js
+++ b/.infrastructure/webpack/webpack-hot-dev-server.config.js
@@ -1,7 +1,7 @@
 var config = require('./make-webpack-config')({
   devServer: true,
   hotComponents: true,
-  devtool: '#cheap-module-eval-source-map',
+  devtool: '#inline-source-map',
   separateStylesheet: true,
   debug: true
 })


### PR DESCRIPTION
For whatever reason the cheap-module-eval-source-map
option is not working for using Chrome. #inline-source-map 
seems to work just fine. See this comment (and thread): 
https://github.com/webpack/webpack/issues/2145#issuecomment-227657507
